### PR TITLE
Added encryption for pdfras.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.9.0)
-project(pdfraster C CXX)
-
-set(CMAKE_CXX_STANDARD 14)
+project(pdfraster C)
 
 set(PDFRASTER_SHARED_LIB pdfraster)
 set(PDFRASTER_STATIC_LIB pdfraster_static)
@@ -20,28 +18,50 @@ endif()
 file(GLOB COMMON_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/common/*.c")
 file(GLOB PDFRAS_READER_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/pdfras_reader/*.c")
 file(GLOB PDFRAS_WRITER_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/pdfras_writer/*.c")
+file(GLOB PDFRAS_DIGSIG_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/pdfras_digitalsignature/*.c")
+file(GLOB PDFRAS_ENCRYPTION_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/pdfras_encryption/*.c")
 
 file(GLOB COMMON_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/common/*.h")
 file(GLOB PDFRAS_READER_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/pdfras_reader/*.h")
 file(GLOB PDFRAS_WRITER_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/pdfras_writer/*.h")
 file(GLOB ICC_PROFILE_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/icc_profile/*.h")
+file(GLOB PDFRAS_DISIG_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/pdfras_digitalsignature/*.h")
+file(GLOB PDFRAS_ENCRYPTION_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/pdfras_encryption/*.h")
 
-add_library(${PDFRASTER_SHARED_LIB} SHARED ${COMMON_SRCS} ${PDFRAS_READER_SRCS} ${PDFRAS_WRITER_SRCS})
+add_library(${PDFRASTER_SHARED_LIB} SHARED 
+    ${COMMON_SRCS} 
+    ${PDFRAS_READER_SRCS} 
+    ${PDFRAS_WRITER_SRCS}
+    ${PDFRAS_DIGSIG_SRCS}
+    ${PDFRAS_ENCRYPTION_SRCS})
 target_include_directories(${PDFRASTER_SHARED_LIB} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/common")
 target_include_directories(${PDFRASTER_SHARED_LIB} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/icc_profile")
 target_include_directories(${PDFRASTER_SHARED_LIB} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/pdfras_reader")
 target_include_directories(${PDFRASTER_SHARED_LIB} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/pdfras_writer")
+target_include_directories(${PDFRASTER_SHARED_LIB} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/pdfras_digitalsignature")
+target_include_directories(${PDFRASTER_SHARED_LIB} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/pdfras_encryption")
 target_link_libraries(${PDFRASTER_SHARED_LIB} ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})
 
-add_library(${PDFRASTER_STATIC_LIB} STATIC ${COMMON_SRCS} ${PDFRAS_READER_SRCS} ${PDFRAS_WRITER_SRCS})
+add_library(${PDFRASTER_STATIC_LIB} STATIC 
+    ${COMMON_SRCS} 
+    ${PDFRAS_READER_SRCS} 
+    ${PDFRAS_WRITER_SRCS}
+    ${PDFRAS_DIGSIG_SRCS}
+    ${PDFRAS_ENCRYPTION_SRCS})
 target_include_directories(${PDFRASTER_STATIC_LIB} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/common")
 target_include_directories(${PDFRASTER_STATIC_LIB} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/icc_profile")
 target_include_directories(${PDFRASTER_STATIC_LIB} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/pdfras_reader")
 target_include_directories(${PDFRASTER_STATIC_LIB} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/pdfras_writer")
+target_include_directories(${PDFRASTER_STATIC_LIB} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/pdfras_digitalsignature")
+target_include_directories(${PDFRASTER_STATIC_LIB} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/pdfras_encryption")
 target_link_libraries(${PDFRASTER_STATIC_LIB} ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})
 
 install(TARGETS ${PDFRASTER_SHARED_LIB} LIBRARY DESTINATION lib)
 install(TARGETS ${PDFRASTER_STATIC_LIB} ARCHIVE DESTINATION lib)
 install(DIRECTORY DESTINATION "include/pdfraster")
-install(FILES ${COMMON_HEADERS} ${PDFRAS_READER_HEADERS} ${PDFRAS_WRITER_HEADERS} ${ICC_PROFILE_HEADERS}
-        DESTINATION "include/pdfraster")
+install(FILES ${COMMON_HEADERS} 
+    ${PDFRAS_READER_HEADERS} 
+    ${PDFRAS_WRITER_HEADERS} 
+    ${ICC_PROFILE_HEADERS}
+    ${PDFRAS_DISIG_HEADERS}
+    ${PDFRAS_ENCRYPTION_HEADERS} DESTINATION "include/pdfraster")

--- a/demo_low_level/demo_low_level.vcxproj
+++ b/demo_low_level/demo_low_level.vcxproj
@@ -87,7 +87,7 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)common;$(SolutionDir)pdfras_encryption;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
     </ClCompile>
@@ -104,7 +104,7 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)common;$(SolutionDir)pdfras_encryption;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
     </ClCompile>
@@ -123,7 +123,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)common;$(SolutionDir)pdfras_encryption;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
     </ClCompile>
@@ -144,7 +144,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)common;$(SolutionDir)pdfras_encryption;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
     </ClCompile>
@@ -160,6 +160,9 @@
     <ClCompile Include="demo_low_level.c" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\pdfras_encryption\pdfras_encryption.vcxproj">
+      <Project>{830942a3-b9b6-4bea-a5aa-213da65c6e1b}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\pdfras_writer\pdfras_writer.vcxproj">
       <Project>{f96f701b-73f9-4bab-ba84-ceff8a112289}</Project>
     </ProjectReference>

--- a/demo_low_level/demo_low_level.vcxproj
+++ b/demo_low_level/demo_low_level.vcxproj
@@ -160,6 +160,9 @@
     <ClCompile Include="demo_low_level.c" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\pdfras_digitalsignature\pdfras_digitalsignature.vcxproj">
+      <Project>{ad94958a-b236-416c-b217-2bad5ecf7cc3}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\pdfras_encryption\pdfras_encryption.vcxproj">
       <Project>{830942a3-b9b6-4bea-a5aa-213da65c6e1b}</Project>
     </ProjectReference>

--- a/demo_raster_encoder/demo_raster_encoder.c
+++ b/demo_raster_encoder/demo_raster_encoder.c
@@ -314,7 +314,7 @@ int write_bitonal_uncompressed_multistrip_file(t_OS os, const char *filename)
 	pdfr_encoder_set_creator(enc, "raster_encoder_demo 1.0");
 	pdfr_encoder_set_subject(enc, "BW 1-bit Uncompressed multi-strip sample output");
 
-	write_bitonal_uncomp_multistrip_page(enc);
+    write_bitonal_uncomp_multistrip_page(enc);
 
 	// the document is complete
 	pdfr_encoder_end_document(enc);
@@ -870,6 +870,122 @@ int write_rgb24_jpeg_file(t_OS os, const char *filename)
     return 0;
 }
 
+int write_rgb24_jpeg_file_encrypted_rc4_40(t_OS os, const char* filename) {
+    // Write a file: JPEG-compressed color US letter page (stored upside-down)
+    FILE *fp = fopen(filename, "wb");
+    if (fp == 0) {
+        fprintf(stderr, "unable to open %s for writing\n", filename);
+        return 1;
+    }
+    os.writeoutcookie = fp;
+    os.allocsys = pd_alloc_new_pool(&os);
+
+    t_pdfrasencoder* enc = pdfr_encoder_create(PDFRAS_API_LEVEL, &os);
+    pdfr_encoder_set_RC4_40_encrypter(enc, "open", "master", PDFRAS_PERM_COPY_FROM_DOCUMENT, PD_FALSE);
+    pdfr_encoder_set_creator(enc, "raster_encoder_demo 1.0");
+    pdfr_encoder_set_title(enc, filename);
+    pdfr_encoder_set_subject(enc, "24-bit JPEG-compressed sample output");
+
+    pdfr_encoder_write_document_xmp(enc, XMP_metadata);
+
+    write_rgb24_jpeg_page(enc);
+
+    // the document is complete
+    pdfr_encoder_end_document(enc);
+    // clean up
+    fclose(fp);
+    pdfr_encoder_destroy(enc);
+    printf("  %s\n", filename);
+    return 0;
+}
+
+int write_rgb24_jpeg_file_encrypted_rc4_128(t_OS os, const char* filename) {
+    // Write a file: JPEG-compressed color US letter page (stored upside-down)
+    FILE *fp = fopen(filename, "wb");
+    if (fp == 0) {
+        fprintf(stderr, "unable to open %s for writing\n", filename);
+        return 1;
+    }
+    os.writeoutcookie = fp;
+    os.allocsys = pd_alloc_new_pool(&os);
+
+    t_pdfrasencoder* enc = pdfr_encoder_create(PDFRAS_API_LEVEL, &os);
+    pdfr_encoder_set_RC4_128_encrypter(enc, "open", "master", PDFRAS_PERM_COPY_FROM_DOCUMENT, PD_FALSE);
+    pdfr_encoder_set_creator(enc, "raster_encoder_demo 1.0");
+    pdfr_encoder_set_title(enc, filename);
+    pdfr_encoder_set_subject(enc, "24-bit JPEG-compressed sample output");
+
+    pdfr_encoder_write_document_xmp(enc, XMP_metadata);
+
+    write_rgb24_jpeg_page(enc);
+
+    // the document is complete
+    pdfr_encoder_end_document(enc);
+    // clean up
+    fclose(fp);
+    pdfr_encoder_destroy(enc);
+    printf("  %s\n", filename);
+    return 0;
+}
+
+int write_rgb24_jpeg_file_encrypted_aes128(t_OS os, const char* filename) {
+    // Write a file: JPEG-compressed color US letter page (stored upside-down)
+    FILE *fp = fopen(filename, "wb");
+    if (fp == 0) {
+        fprintf(stderr, "unable to open %s for writing\n", filename);
+        return 1;
+    }
+    os.writeoutcookie = fp;
+    os.allocsys = pd_alloc_new_pool(&os);
+
+    t_pdfrasencoder* enc = pdfr_encoder_create(PDFRAS_API_LEVEL, &os);
+    pdfr_encoder_set_AES128_encrypter(enc, "open", "master", PDFRAS_PERM_COPY_FROM_DOCUMENT, PD_FALSE);
+    pdfr_encoder_set_creator(enc, "raster_encoder_demo 1.0");
+    pdfr_encoder_set_title(enc, filename);
+    pdfr_encoder_set_subject(enc, "24-bit JPEG-compressed sample output");
+
+    pdfr_encoder_write_document_xmp(enc, XMP_metadata);
+
+    write_rgb24_jpeg_page(enc);
+
+    // the document is complete
+    pdfr_encoder_end_document(enc);
+    // clean up
+    fclose(fp);
+    pdfr_encoder_destroy(enc);
+    printf("  %s\n", filename);
+    return 0;
+}
+
+int write_rgb24_jpeg_file_encrypted_aes256(t_OS os, const char* filename) {
+    // Write a file: JPEG-compressed color US letter page (stored upside-down)
+    FILE *fp = fopen(filename, "wb");
+    if (fp == 0) {
+        fprintf(stderr, "unable to open %s for writing\n", filename);
+        return 1;
+    }
+    os.writeoutcookie = fp;
+    os.allocsys = pd_alloc_new_pool(&os);
+
+    t_pdfrasencoder* enc = pdfr_encoder_create(PDFRAS_API_LEVEL, &os);
+    pdfr_encoder_set_AES256_encrypter(enc, "open", "master", PDFRAS_PERM_COPY_FROM_DOCUMENT, PD_FALSE);
+    pdfr_encoder_set_creator(enc, "raster_encoder_demo 1.0");
+    pdfr_encoder_set_title(enc, filename);
+    pdfr_encoder_set_subject(enc, "24-bit JPEG-compressed sample output");
+
+    pdfr_encoder_write_document_xmp(enc, XMP_metadata);
+
+    write_rgb24_jpeg_page(enc);
+
+    // the document is complete
+    pdfr_encoder_end_document(enc);
+    // clean up
+    fclose(fp);
+    pdfr_encoder_destroy(enc);
+    printf("  %s\n", filename);
+    return 0;
+}
+
 void write_gray8_jpeg_multistrip_page(t_pdfrasencoder* enc)
 {
 	pdfr_encoder_set_resolution(enc, 100.0, 100.0);
@@ -1093,6 +1209,11 @@ int main(int argc, char** argv)
 	write_rgb48_uncompressed_multistrip_file(os, "sample rgb48 uncompressed multistrip.pdf");
 
 	write_allformat_multipage_file(os, "sample all formats.pdf");
+
+    write_rgb24_jpeg_file_encrypted_rc4_40(os, "sample rgb24 jpeg rc40.pdf");
+    write_rgb24_jpeg_file_encrypted_rc4_128(os, "sample rgb24 jpeg rc128.pdf");
+    write_rgb24_jpeg_file_encrypted_aes128(os, "sample rgb24 jpeg aes128.pdf");
+    write_rgb24_jpeg_file_encrypted_aes256(os, "sample rgb24 jpeg aes256.pdf");
 
     printf("------------------------------\n");
     printf("Hit [enter] to exit:\n");

--- a/demo_raster_encoder/demo_raster_encoder.c
+++ b/demo_raster_encoder/demo_raster_encoder.c
@@ -299,6 +299,43 @@ int write_bitonal_uncompressed_signed_file(t_OS os, const char* filename, const 
     return 0;
 }
 
+int write_bitonal_uncompressed_signed_and_encrypted_file(t_OS os, const char* filename, const char* image_path) {
+    FILE *fp = fopen(filename, "wb");
+    if (fp == 0) {
+        fprintf(stderr, "unable to open %s for writing\n", filename);
+        return 1;
+    }
+    os.writeoutcookie = fp;
+    os.allocsys = pd_alloc_new_pool(&os);
+
+    // Construct a raster PDF encoder
+    char cert_path[256];
+    memset(cert_path, 0, 256);
+    char* demo = strstr(image_path, "demo_raster_encoder");
+    strncpy(cert_path, image_path, demo - image_path);
+    sprintf(cert_path + (demo - image_path), "%s", "certificate.p12");
+    t_pdfrasencoder* enc = pdfr_signed_encoder_create(PDFRAS_API_LEVEL, &os, cert_path, "");
+    pdfr_encoder_set_AES128_encrypter(enc, "open", "master", PDFRAS_PERM_COPY_FROM_DOCUMENT, PD_TRUE);
+
+    pdfr_encoder_set_creator(enc, "raster_encoder_demo 1.0");
+    pdfr_encoder_set_subject(enc, "BW 1-bit Uncompressed sample output");
+
+    t_pdfdigitalsignature* signature = pdfr_encoder_get_digitalsignature(enc);
+    pdfr_digitalsignature_set_location(signature, "Nove Zamky");
+    pdfr_digitalsignature_set_name(signature, "Mato");
+    pdfr_digitalsignature_set_reason(signature, "Test of signing and encryption.");
+
+    write_bitonal_uncomp_page(enc);
+
+    // the document is complete
+    pdfr_encoder_end_document(enc);
+    // clean up
+    fclose(fp);
+    pdfr_encoder_destroy(enc);
+    printf("  %s\n", filename);
+    return 0;
+}
+
 int write_bitonal_uncompressed_multistrip_file(t_OS os, const char *filename)
 {
 	FILE *fp = fopen(filename, "wb");
@@ -1175,6 +1212,8 @@ int main(int argc, char** argv)
 	write_bitonal_uncompressed_file(os, "sample bw1 uncompressed.pdf");
 
     write_bitonal_uncompressed_signed_file(os, "sample bw1 uncompressed signed.pdf", argv[0]);
+
+    write_bitonal_uncompressed_signed_and_encrypted_file(os, "sample bw1 uncompressed signed and encrypted AES128.pdf", argv[0]);
 
 	write_bitonal_uncompressed_multistrip_file(os, "sample bw1 uncompressed multistrip.pdf");
 

--- a/demo_raster_encoder/demo_raster_encoder.vcxproj
+++ b/demo_raster_encoder/demo_raster_encoder.vcxproj
@@ -87,7 +87,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;..\pdfras_encryption;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
     </ClCompile>
@@ -115,7 +115,7 @@ $(TargetDir)xxd -i color_strip3.jpg color_strip3.h
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;..\pdfras_encryption;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
     </ClCompile>
@@ -145,7 +145,7 @@ $(TargetDir)xxd -i color_strip3.jpg color_strip3.h
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;..\pdfras_encryption;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
     </ClCompile>
@@ -177,7 +177,7 @@ $(TargetDir)xxd -i color_strip3.jpg color_strip3.h
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;..\pdfras_encryption;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
     </ClCompile>
@@ -217,6 +217,9 @@ $(TargetDir)xxd -i color_strip3.jpg color_strip3.h
   <ItemGroup>
     <ProjectReference Include="..\pdfras_digitalsignature\pdfras_digitalsignature.vcxproj">
       <Project>{ad94958a-b236-416c-b217-2bad5ecf7cc3}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\pdfras_encryption\pdfras_encryption.vcxproj">
+      <Project>{830942a3-b9b6-4bea-a5aa-213da65c6e1b}</Project>
     </ProjectReference>
     <ProjectReference Include="..\pdfras_writer\pdfras_writer.vcxproj">
       <Project>{f96f701b-73f9-4bab-ba84-ceff8a112289}</Project>

--- a/pdfras_digitalsignature/pdfras_digitalsignature.c
+++ b/pdfras_digitalsignature/pdfras_digitalsignature.c
@@ -32,7 +32,7 @@ pdbool static load_ceratificate(t_signer* signer, const char* file, const char* 
 
     pkcs12 = d2i_PKCS12_bio(bio_file, NULL);
     BIO_free(bio_file);
-#elif
+#else
     pfx_file = fopen(file, "rb");
     if (!pfx_file)
         return PD_FALSE;

--- a/pdfras_digitalsignature/pdfras_digitalsignature.vcxproj
+++ b/pdfras_digitalsignature/pdfras_digitalsignature.vcxproj
@@ -93,7 +93,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;PDFRAS_DIGITALSIGNATURE_EXPORTS;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\pdfras_writer;..\pdfras_openssl;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\pdfras_writer;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -115,7 +115,7 @@ copy $(MSBuildThisFileDirectory)certificate.p12 $(MSBuildThisFileDirectory)..\bi
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;PDFRAS_DIGITALSIGNATURE_EXPORTS;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\pdfras_writer;..\pdfras_openssl;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\pdfras_writer;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -139,7 +139,7 @@ copy $(MSBuildThisFileDirectory)certificate.p12 $(MSBuildThisFileDirectory)..\bi
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;PDFRAS_DIGITALSIGNATURE_EXPORTS;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\pdfras_writer;..\pdfras_openssl;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\pdfras_writer;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -165,7 +165,7 @@ copy $(MSBuildThisFileDirectory)certificate.p12 $(MSBuildThisFileDirectory)..\bi
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;PDFRAS_DIGITALSIGNATURE_EXPORTS;%(PreprocessorDefinitions);_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\pdfras_writer;..\pdfras_openssl;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\pdfras_writer;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/pdfras_encryption/Header.h
+++ b/pdfras_encryption/Header.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/pdfras_encryption/aes_crypter.c
+++ b/pdfras_encryption/aes_crypter.c
@@ -1,0 +1,51 @@
+// aes_crypter.c - AES encryption/decryption
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "aes_crypter.h"
+#include "openssl/rand.h"
+#include "openssl/evp.h"
+#include "openssl/aes.h"
+
+#define IV_LEN 16
+
+pduint32 pdfras_aes_encrypt_data(const char* key, const pduint32 key_len, const char* data_in, const pdint32 in_len, char* data_out) {
+    if (data_in == NULL || data_out == NULL)
+        return -1;
+
+    char iv[IV_LEN];
+    pdfras_generate_random_bytes(iv, IV_LEN);
+
+    EVP_CIPHER_CTX* cipher = EVP_CIPHER_CTX_new();
+
+    if (key_len <= 16)
+        EVP_EncryptInit(cipher, EVP_aes_128_cbc(), key, iv);
+    else if (key_len == 32)
+        EVP_EncryptInit(cipher, EVP_aes_256_cbc(), key, iv);
+    else
+        return -1;
+
+    memcpy(data_out, iv, IV_LEN);
+
+    int out_len, padded_len;;
+    EVP_EncryptUpdate(cipher, data_out + IV_LEN, &out_len, data_in, in_len);
+    EVP_EncryptFinal_ex(cipher, data_out + IV_LEN + out_len, &padded_len);
+
+    EVP_CIPHER_CTX_free(cipher);
+
+    return out_len + padded_len;
+}
+
+void pdfras_generate_random_bytes(char* buf, pdint32 buf_len) {
+    if (RAND_bytes(buf, buf_len) == 0) {
+        // try pseudo random generator
+        if (RAND_pseudo_bytes(buf, buf_len) == 0) {
+            // ok, openssl failed to generate random nums
+            srand((unsigned int)time(NULL));
+            for (pdint32 i = 0; i < buf_len; ++i) {
+                buf[i] = (char)rand();
+            }
+        }
+    }
+}

--- a/pdfras_encryption/aes_crypter.h
+++ b/pdfras_encryption/aes_crypter.h
@@ -1,0 +1,17 @@
+#ifndef _H_AESCrypter
+#define _H_AESCrypter
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "PdfPlatform.h"
+
+extern pduint32 pdfras_aes_encrypt_data(const char* key, const pduint32 key_len, const char* data_in, const pdint32 in_len, char* data_out);
+extern void pdfras_generate_random_bytes(char* buf, pdint32 buf_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _H_AESCrypter

--- a/pdfras_encryption/pdfras_encryption.c
+++ b/pdfras_encryption/pdfras_encryption.c
@@ -1,0 +1,794 @@
+// pdras_encryption.c - encryption support for pdfraster
+
+#include <string.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#include "openssl/md5.h"
+#include "openssl/rc4.h"
+#include "openssl/sha.h"
+#include "openssl/aes.h"
+#include "openssl/evp.h"
+
+#include "pdfras_encryption.h"
+#include "rc4_crypter.h"
+#include "aes_crypter.h"
+
+#define MD5_HASH_BYTES  16
+#define R_6_KEY_LENGTH  32
+
+struct t_encrypter {
+    // user entered data
+    char* user_password;  // Only for PDF 2.0
+    char* owner_password; // Only for PDF 2.0
+
+    char padded_up[32];
+    char padded_op[32];
+
+    char* O;
+    char* U;
+    char* OE;
+    char* UE;
+    char* Perms;
+    PDFRAS_PERMS perms;
+    PDFRAS_ENCRYPT_ALGORITHM algorithm;
+    pdbool encrypt_metadata;
+
+    pduint32 OU_length;
+    pduint32 OUE_length;
+    pduint32 Perms_length;
+
+    pduint8 V;
+    pduint8 R;
+
+    char* document_id;
+    pduint32 document_id_length;
+    
+    // encryption key
+    char* encryption_key;
+    pduint16 encryption_key_length;
+
+    pdint32 current_obj_number;
+    pdint32 current_gen_number;
+};
+
+static char password_padding[] = "\x28\xBF\x4E\x5E\x4E\x75\x8A\x41\x64\x00\x4E\x56\xFF\xFA\x01\x08\x2E\x2E\x00\xB6\xD0\x68\x3E\x80\x2F\x0C\xA9\xFE\x64\x53\x69\x7A";
+
+static void padd_passwords(t_encrypter* enc, const char* user_password, const char* owner_password) {
+    // a
+    pdint32 len = 0;
+    pdint32 idx = 0;
+    if (owner_password) {
+        len = strlen(owner_password);
+        memcpy(enc->padded_op, owner_password, len > 32 ? 32 : len);
+
+        // pad password
+        while (len < 32)
+            enc->padded_op[len++] = password_padding[idx++];
+    }
+    else
+        memcpy(enc->padded_op, password_padding, 32);
+
+    idx = 0;
+    if (user_password) {
+        len = strlen(user_password);
+        memcpy(enc->padded_up, user_password, len > 32 ? 32 : len);
+
+        // pad password
+        while (len < 32)
+            enc->padded_up[len++] = password_padding[idx++];
+    }
+    else
+        memcpy(enc->padded_up, password_padding, 32);
+}
+
+// Alogrithm 3: Computing the encryption dictionary's O (owner password) value
+static pdbool compute_O(t_encrypter* enc) {
+    MD5_CTX md5;
+    unsigned char hash[MD5_HASH_BYTES];
+
+    if (MD5_Init(&md5) == 0)
+        return PD_FALSE;
+
+    // a, b
+    MD5_Update(&md5, enc->padded_op, 32);
+    MD5_Final(hash, &md5);
+
+    // c
+    if (enc->R >= 3) {
+        for (pduint32 i = 0; i < 50; ++i) {
+            MD5_Init(&md5);
+            MD5_Update(&md5, hash, enc->encryption_key_length);
+            MD5_Final(hash, &md5);
+        }
+    }
+
+    // d
+    RC4_KEY rc4_key;
+    RC4_set_key(&rc4_key, enc->encryption_key_length, hash);
+
+    // e done by previous function
+    // f
+    RC4(&rc4_key, 32, enc->padded_up, enc->O);
+
+    // g
+    if (enc->R >= 3) {
+        unsigned char key[MD5_HASH_BYTES];
+
+        for (pduint32 i = 1; i <= 19; ++i) {
+            for (pduint32 k = 0; k < enc->encryption_key_length; ++k) {
+                key[k] = (unsigned char)(hash[k] ^ i);
+            }
+
+            RC4_set_key(&rc4_key, enc->encryption_key_length, key);
+            RC4(&rc4_key, 32, enc->O, enc->O);
+        }
+    }
+    
+    // h -> O already stored
+
+    return PD_TRUE;
+}
+
+// Algorithm 4: Compute U value (revision 2)
+static pdbool compute_U_r2(t_encrypter* enc) {
+    if (enc->encryption_key == NULL)
+        return PD_FALSE;
+
+    RC4_KEY rc4_key;
+    RC4_set_key(&rc4_key, enc->encryption_key_length, enc->encryption_key);
+    RC4(&rc4_key, 32, password_padding, enc->U);
+
+    return PD_TRUE;
+}
+
+// Algorithm 5: Compute U value (revision >= 3)
+static pdbool compute_U_r3_4(t_encrypter* enc) {
+    unsigned char hash[MD5_HASH_BYTES];
+
+    if (enc->encryption_key == NULL)
+        return PD_FALSE;
+
+    MD5_CTX md5;
+    if (MD5_Init(&md5) == 0)
+        return PD_FALSE;
+
+    // b
+    MD5_Update(&md5, password_padding, 32);
+
+    // c
+    MD5_Update(&md5, enc->document_id, enc->document_id_length);
+    MD5_Final(hash, &md5);
+
+    // d
+    RC4_KEY rc4_key;
+    unsigned char rc4_hash[16];
+    RC4_set_key(&rc4_key, enc->encryption_key_length, enc->encryption_key);
+    RC4(&rc4_key, 16, hash, rc4_hash);
+
+    // e
+    unsigned char key[MD5_HASH_BYTES];
+    for (pduint32 i = 1; i <= 19; ++i) {
+        for (pduint32 k = 0; k < enc->encryption_key_length; ++k) {
+            key[k] = (unsigned char)(enc->encryption_key[k] ^ i);
+        }
+
+        RC4_set_key(&rc4_key, enc->encryption_key_length, key);
+        RC4(&rc4_key, MD5_HASH_BYTES, rc4_hash, rc4_hash);
+    }
+
+    // f
+    memcpy(enc->U, rc4_hash, MD5_HASH_BYTES);
+    memcpy(enc->U + MD5_HASH_BYTES, password_padding, MD5_HASH_BYTES);
+
+    return PD_TRUE;
+}
+
+// Algorithm 2.B, PDF 2.0
+static void compute_2B(const char* password, const pduint8* salt, const pduint8* additional, pduint8* hash) {
+    // Algorithm 2.B from ISO 32000-2 to compute hash from password
+
+    pdint32 length = 0;
+    if (password != NULL)
+        length = strlen(password);
+    if (length > 127)
+        length = 127;
+
+    pduint8 K[64]; 
+    pduint16 K_length = 32;
+    SHA256_CTX sha256;
+    SHA256_Init(&sha256);
+    SHA256_Update(&sha256, (const unsigned char *)password, length);
+    SHA256_Update(&sha256, salt, 8);
+    if (additional != NULL)
+        SHA256_Update(&sha256, additional, 48);
+    SHA256_Final(K, &sha256);
+
+    unsigned int last = 0;
+    EVP_CIPHER_CTX* aes128 = EVP_CIPHER_CTX_new();
+    for (unsigned int step = 0; step < 64 || last > step - 32; step++) {
+
+        // step a
+        pduint8 K1[15962] = "";
+        pdint32 K1_length = 0;
+        memcpy((unsigned char*)K1, password, length);
+        K1_length += length;
+        memcpy(&K1[K1_length], K, K_length);
+        K1_length += K_length;
+        if (additional != NULL) {
+            memcpy(&K1[K1_length], additional, 48);
+            K1_length += 48;
+        }
+        for (int i = 0; i < 6; i++) {
+            memcpy(&K1[K1_length], K1, K1_length);
+            K1_length = K1_length << 1;
+        }
+
+        // step b
+        pduint8 E[sizeof(K1)] = "";
+        int E_length = 0, len = 0;
+        
+        EVP_EncryptInit(aes128, EVP_aes_128_cbc(), K, &K[16]);
+        EVP_CIPHER_CTX_set_padding(aes128, 0);
+        EVP_EncryptUpdate(aes128, E, &len, (const unsigned char*)&K1, K1_length);
+        E_length = len;
+        EVP_EncryptFinal_ex(aes128, E + len, &len);
+        E_length += len;
+
+        // step c
+        unsigned int sum = 0;
+        for (int i = 0; i < 16; i++)
+            sum += E[i];
+
+        // step d
+        switch (sum % 3) {
+            case 1: {
+                SHA512_CTX sha384;
+                SHA384_Init(&sha384);
+                SHA384_Update(&sha384, (const unsigned char *)E, E_length);
+                SHA384_Final(K, &sha384);
+                K_length = SHA384_DIGEST_LENGTH;
+            }
+                break;
+            case 2: {
+                SHA512_CTX sha512;
+                SHA512_Init(&sha512);
+                SHA512_Update(&sha512, (const unsigned char *)E, E_length);
+                SHA512_Final(K, &sha512);
+                K_length = SHA512_DIGEST_LENGTH;
+            }
+                break;
+            case 0:
+            default: {
+                SHA256_CTX sha256;
+                SHA256_Init(&sha256);
+                SHA256_Update(&sha256, (const unsigned char *)E, E_length);
+                SHA256_Final(K, &sha256);
+                K_length = SHA256_DIGEST_LENGTH;
+            }
+                break;
+        }
+
+        // step e,f
+        last = E[E_length - 1];
+    }
+
+    EVP_CIPHER_CTX_free(aes128);
+
+    memcpy(hash, K, 32);
+}
+
+// Algorithm 8: Computing the encryption dictionary's U and UE values (R == 6)
+static pdbool compute_U_UE_r_6(t_encrypter* enc) {
+    pduint8 buffer[16];
+    pdfras_generate_random_bytes(buffer, 16);
+
+    pduint8* uValSalt = buffer;
+    pduint8* uKeySalt = buffer + 8;
+
+    // U
+    compute_2B(enc->user_password, uValSalt, NULL, enc->U);
+    memcpy(enc->U + 32, buffer, sizeof(buffer));
+
+    // UE
+    pduint8 ue_key[32];
+    compute_2B(enc->user_password, uKeySalt, NULL, ue_key);
+    pduint8 iv[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    int len;
+    EVP_CIPHER_CTX* aes256 = EVP_CIPHER_CTX_new();
+    EVP_EncryptInit(aes256, EVP_aes_256_cbc(), ue_key, iv);
+    EVP_CIPHER_CTX_set_padding(aes256, 0);
+    EVP_EncryptUpdate(aes256, enc->UE, &len, (const unsigned char*)enc->encryption_key, 32);
+    EVP_EncryptFinal_ex(aes256, enc->UE + len, &len);
+
+    EVP_CIPHER_CTX_free(aes256);
+
+    return PD_TRUE;
+}
+
+// Algorithm 9: Computing the encryption dictionary's O and OE values (R == 6)
+static pdbool compute_O_OE_r_6(t_encrypter* enc) {
+    if (!enc->U)
+        return PD_FALSE;
+
+    pduint8 buffer[16];
+    pdfras_generate_random_bytes(buffer, 16);
+
+    pduint8* oValSalt = buffer;
+    pduint8* oKeySalt = buffer + 8;
+
+    // O
+    compute_2B(enc->owner_password, oValSalt, enc->U, enc->O);
+    memcpy(enc->O + 32, buffer, sizeof(buffer));
+
+    // OE
+    pduint8 oe_key[32];
+    compute_2B(enc->owner_password, oKeySalt, enc->U, oe_key);
+    
+    pduint8 iv[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    int len;
+    EVP_CIPHER_CTX* aes256 = EVP_CIPHER_CTX_new();
+    EVP_EncryptInit(aes256, EVP_aes_256_cbc(), oe_key, iv);
+    EVP_CIPHER_CTX_set_padding(aes256, 0);
+    EVP_EncryptUpdate(aes256, enc->OE, &len, (const unsigned char*)enc->encryption_key, 32);
+    EVP_EncryptFinal_ex(aes256, enc->OE + len, &len);
+    
+    EVP_CIPHER_CTX_free(aes256);
+
+    return PD_TRUE;
+}
+
+// Algorithm 10: computing Perms entry for encryption dictionary (R == 6)
+static pdbool compute_Perms(t_encrypter* enc) {
+    // steps a,b
+    pduint8 perms_buffer[16];
+    perms_buffer[0] = (pduint8)(enc->perms & 0xFF);
+    perms_buffer[1] = (pduint8)((enc->perms >> 8) & 0xFF);
+    perms_buffer[2] = (pduint8)((enc->perms >> 16) & 0xFF);
+    perms_buffer[3] = (pduint8)((enc->perms >> 24) & 0xFF);
+    perms_buffer[4] = (pduint8)(0xFF);
+    perms_buffer[5] = (pduint8)(0xFF);
+    perms_buffer[6] = (pduint8)(0xFF);
+    perms_buffer[7] = (pduint8)(0xFF);
+
+    // step c
+    perms_buffer[8] = enc->encrypt_metadata ? 'T' : 'F';
+
+    // step d
+    perms_buffer[9] = 'a';
+    perms_buffer[10] = 'd';
+    perms_buffer[11] = 'b';
+
+    // step e - //random numbers. let's use: 'TwAi'
+    perms_buffer[12] = 'T';
+    perms_buffer[13] = 'w';
+    perms_buffer[14] = 'A';
+    perms_buffer[15] = 'i';
+
+    // step f
+    pduint8 iv[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    int len;
+    EVP_CIPHER_CTX* aes256 = EVP_CIPHER_CTX_new();
+    EVP_EncryptInit(aes256, EVP_aes_256_ecb(), enc->encryption_key, iv);
+    EVP_CIPHER_CTX_set_padding(aes256, 0);
+    EVP_EncryptUpdate(aes256, enc->Perms, &len, perms_buffer, sizeof perms_buffer);
+    EVP_EncryptFinal_ex(aes256, enc->Perms + len, &len);
+
+    EVP_CIPHER_CTX_free(aes256);
+    
+    return PD_TRUE;
+}
+
+// Algorithm 2: Computing encryption key
+static pdbool generate_encryption_key(t_encrypter* enc) {
+    if (enc->R == 6) {
+        enc->encryption_key = (char*)malloc(sizeof(char) * R_6_KEY_LENGTH);
+        enc->encryption_key_length = R_6_KEY_LENGTH;
+        pdfras_generate_random_bytes(enc->encryption_key, R_6_KEY_LENGTH);
+    }
+    else {
+        pduint8 idx = 0;
+        pduint32 len = 0;
+
+        // a -> passwords already padded
+
+        // b
+        MD5_CTX md5;
+        if (MD5_Init(&md5) == 0)
+            return PD_FALSE;
+
+        //MD5_Update(&md5, padded_op, 32);
+        MD5_Update(&md5, enc->padded_up, 32);
+
+        // c
+        MD5_Update(&md5, enc->O, enc->OU_length);
+
+        // d
+        pduint32 p = (pduint32)enc->perms;
+        pduint8 p_a[4] = { (pduint8)(p), (pduint8)(p >> 8), (pduint8)(p >> 16), (pduint8)(p >> 24) };
+        MD5_Update(&md5, p_a, 4);
+
+        // e
+        if (enc->document_id != NULL)
+            MD5_Update(&md5, enc->document_id, enc->document_id_length);
+
+        if (enc->R >= 4 && !enc->encrypt_metadata) {
+            pduint8 m[4] = { 0xFF, 0xFF, 0xFF, 0xFF };
+            MD5_Update(&md5, m, 4);
+        }
+
+        // f
+        unsigned char hash[MD5_HASH_BYTES];
+        MD5_Final(hash, &md5);
+
+        // g
+        if (enc->R >= 3) {
+            for (int i = 0; i < 50; ++i) {
+                if (MD5_Init(&md5) == 0)
+                    return PD_FALSE;
+
+                MD5_Update(&md5, hash, enc->encryption_key_length);
+                MD5_Final(hash, &md5);
+            }
+        }
+
+        // h
+        enc->encryption_key = (char*)malloc(sizeof(char) * enc->encryption_key_length);
+        memcpy(enc->encryption_key, (const unsigned char*)hash, enc->encryption_key_length);
+    }
+
+    return PD_TRUE;
+}
+
+//TODO: If memory module will be separated, then used PDFRAS memory managment functions
+t_encrypter* pdfr_create_encrypter(const char* user_password, const char* owner_password, PDFRAS_PERMS perms, PDFRAS_ENCRYPT_ALGORITHM algorithm, pdbool metadata) {
+    if (algorithm >= PDFRAS_UNDEFINED_ENCRYPT_ALGORITHM || algorithm < PDFRAS_RC4_40)
+        return NULL;
+
+    t_encrypter* encrypter = (t_encrypter*)malloc(sizeof(t_encrypter));
+
+    encrypter->algorithm = algorithm;
+    encrypter->perms = perms;
+    encrypter->encrypt_metadata = metadata;
+    encrypter->document_id = NULL;
+    encrypter->document_id_length = 0;
+    encrypter->encryption_key = NULL;
+    encrypter->current_obj_number = -1;
+    encrypter->current_gen_number = -1;
+    encrypter->user_password = NULL;
+    encrypter->owner_password = NULL;
+    encrypter->OE = NULL;
+    encrypter->UE = NULL;
+    encrypter->Perms = NULL;
+    encrypter->OUE_length = 0;
+    encrypter->Perms_length = 0;
+
+    switch (encrypter->algorithm)
+    {
+    case PDFRAS_RC4_40:
+        encrypter->V = 1;
+        encrypter->R = 2;
+        encrypter->encryption_key_length = 5;
+        break;
+    case PDFRAS_RC4_128:
+    case PDFRAS_AES_128:
+        encrypter->V = 4;
+        encrypter->R = 4;
+        encrypter->encryption_key_length = 16;
+        break;
+    case PDFRAS_AES_256:
+        encrypter->V = 5; // PDF 2.0
+        encrypter->R = 6; // PDF 2.0
+        encrypter->encryption_key_length = 32;
+        break;
+    default:
+        break;
+    }
+
+    if (encrypter->R <= 4) {
+        encrypter->OU_length = 32;
+        encrypter->O = (char*)malloc(encrypter->OU_length * sizeof(char));
+        encrypter->U = (char*)malloc(encrypter->OU_length * sizeof(char));        
+    }
+    else if (encrypter->R >= 6) {
+        encrypter->OU_length = 48;
+        encrypter->O = (char*)malloc(encrypter->OU_length * sizeof(char));
+        encrypter->U = (char*)malloc(encrypter->OU_length * sizeof(char));
+
+        encrypter->OUE_length = 32;
+        encrypter->OE = (char*)malloc(encrypter->OUE_length * sizeof(char));
+        encrypter->UE = (char*)malloc(encrypter->OUE_length * sizeof(char));
+
+        encrypter->Perms_length = 16;
+        encrypter->Perms = (char*)malloc(encrypter->Perms_length * sizeof(char));
+
+        if (user_password) {
+            pdint32 len = strlen(user_password);
+            encrypter->user_password = (char*)malloc(sizeof(char) * (len + 1));
+            strncpy(encrypter->user_password, user_password, len);
+            encrypter->user_password[len] = '\0';
+        }
+
+        if (owner_password) {
+            pdint32 len = strlen(owner_password);
+            encrypter->owner_password = (char*)malloc(sizeof(char) * (len + 1));
+            strncpy(encrypter->owner_password, owner_password, len);
+            encrypter->owner_password[len] = '\0';
+        }
+    }
+    else {
+        encrypter->O = NULL;
+        encrypter->U = NULL;
+        encrypter->OU_length = 0;
+    }
+
+    padd_passwords(encrypter, user_password, owner_password);
+
+    return encrypter;
+}
+
+void pdfr_destroy_encrypter(t_encrypter* encrypter) {
+    if (encrypter) {
+        if (encrypter->O)
+            free(encrypter->O);
+
+        if (encrypter->U)
+            free(encrypter->U);
+
+        if (encrypter->document_id)
+            free(encrypter->document_id);
+
+        if (encrypter->encryption_key)
+            free(encrypter->encryption_key);
+
+        if (encrypter->user_password)
+            free(encrypter->user_password);
+
+        if (encrypter->owner_password)
+            free(encrypter->owner_password);
+
+        if (encrypter->UE)
+            free(encrypter->UE);
+
+        if (encrypter->OE)
+            free(encrypter->OE);
+
+        if (encrypter->Perms)
+            free(encrypter->Perms);
+
+        free(encrypter);
+    }
+}
+
+void pdfr_encrypter_object_number(t_encrypter* encrypter, pduint32 objnum, pduint32 gennum) {
+    assert(encrypter);
+
+    encrypter->current_obj_number = objnum;
+    encrypter->current_gen_number = gennum;
+}
+
+pdbool pdfr_encrypter_dictionary_data(t_encrypter* encrypter, const char* document_id, pduint32 id_len) {
+    assert(encrypter);
+
+    if (document_id != NULL && id_len > 0) {
+        if (encrypter->document_id != NULL)
+            free(encrypter->document_id);
+
+        encrypter->document_id = (char*)malloc(id_len * sizeof(char));
+        strncpy(encrypter->document_id, document_id, id_len);
+        encrypter->document_id_length = id_len;
+    }
+
+    // compute O
+    if (encrypter->R < 6) {
+        if (compute_O(encrypter) == PD_FALSE)
+            return PD_FALSE;
+
+        // compute encryption key
+        if (generate_encryption_key(encrypter) == PD_FALSE) {
+            return PD_FALSE;
+        }
+
+        if (encrypter->R == 2)
+            compute_U_r2(encrypter);
+        else if (encrypter->R >= 3)
+            compute_U_r3_4(encrypter);
+    }
+    else if (encrypter->R == 6) {
+        // encryption key
+        if (generate_encryption_key(encrypter) == PD_FALSE)
+            return PD_FALSE;
+
+        // U and UE
+        if (compute_U_UE_r_6(encrypter) == PD_FALSE)
+            return PD_FALSE;
+
+        // O and OE
+        if (compute_O_OE_r_6(encrypter) == PD_FALSE)
+            return PD_FALSE;
+        
+        // Perms
+        if (compute_Perms(encrypter) == PD_FALSE)
+            return PD_FALSE;
+    }
+
+    return PD_TRUE;
+}
+
+pdint32 pdfr_encrypter_encrypt_data(t_encrypter* encrypter, const pduint8* data_in, const pdint32 in_len, pduint8* data_out) {
+    assert(encrypter);
+
+    if (data_in == NULL)
+        return -1;
+
+    if (encrypter->current_obj_number <= 0 || encrypter->current_gen_number < 0)
+        return -1;
+
+    pdbool aes = PD_FALSE;
+    if (encrypter->algorithm == PDFRAS_RC4_40 || encrypter->algorithm == PDFRAS_RC4_128)
+        aes = PD_FALSE;
+    else if (encrypter->algorithm == PDFRAS_AES_128 || encrypter->algorithm == PDFRAS_AES_256)
+        aes = PD_TRUE;
+    else
+        return -1;
+
+    int out_len = -1;
+    
+    if (aes)
+        out_len = (in_len + 16 - (in_len % 16)) + 16;
+    else 
+        out_len = in_len;
+    
+    if (data_out == NULL)
+        return out_len;
+
+    pduint32 encryption_key_len = 0;
+    char* encryption_key = NULL;
+
+    if (encrypter->V < 5) {
+        pduint32 obj_key_len = 0;
+
+        obj_key_len = aes == PD_TRUE ? encrypter->encryption_key_length + 9 : encrypter->encryption_key_length + 5;
+
+        char* obj_key = (char*)malloc(sizeof(char) * obj_key_len);
+        if (!obj_key)
+            return -1;
+
+        memcpy(obj_key, encrypter->encryption_key, encrypter->encryption_key_length);
+        obj_key[encrypter->encryption_key_length] = (char)encrypter->current_obj_number;
+        obj_key[encrypter->encryption_key_length + 1] = (char)(encrypter->current_obj_number >> 8);
+        obj_key[encrypter->encryption_key_length + 2] = (char)(encrypter->current_obj_number >> 16);
+        obj_key[encrypter->encryption_key_length + 3] = (char)(encrypter->current_gen_number);
+        obj_key[encrypter->encryption_key_length + 4] = (char)(encrypter->current_gen_number >> 8);
+
+        if (aes) {
+            obj_key[encrypter->encryption_key_length + 5] = (char)0x73;
+            obj_key[encrypter->encryption_key_length + 6] = (char)0x41;
+            obj_key[encrypter->encryption_key_length + 7] = (char)0x6c;
+            obj_key[encrypter->encryption_key_length + 8] = (char)0x54;
+        }
+
+        MD5_CTX md5;
+        char hash[MD5_HASH_BYTES];
+
+        if (MD5_Init(&md5) == 0) {
+            free(obj_key);
+            return -1;
+        }
+
+        MD5_Update(&md5, obj_key, obj_key_len);
+        MD5_Final(hash, &md5);
+
+        encryption_key_len = encrypter->encryption_key_length + 5 > 16 ? 16 : encrypter->encryption_key_length + 5;
+        encryption_key = (char*)malloc(sizeof(char) * encryption_key_len);
+        memcpy(encryption_key, hash, encryption_key_len);
+
+        free(obj_key);
+    }
+    else {
+        encryption_key = encrypter->encryption_key;
+        encryption_key_len = 32;
+    }
+
+    if (aes) {
+        if (pdfras_aes_encrypt_data(encryption_key, encryption_key_len, data_in, in_len, data_out) == 0) {
+            free(encryption_key);
+            return -1;
+        }
+    }
+    else {
+        if (pdfras_rc4_encrypt_data(encryption_key, encryption_key_len, data_in, in_len, data_out) == 0) {
+            free(encryption_key);
+            return -1;
+        }
+    }
+
+    if (encrypter->R < 5)
+        free(encryption_key);
+    
+    return out_len;
+}
+
+pduint8 pdfr_encrypter_get_V(t_encrypter* encrypter) {
+    assert(encrypter);
+    
+    return encrypter->V;
+}
+
+pduint32 pdfr_encrypter_get_key_length(t_encrypter* encrypter) {
+    assert(encrypter);
+
+    return encrypter->encryption_key_length * 8;
+}
+
+pduint8 pdfr_encrypter_get_R(t_encrypter* encrypter) {
+    assert(encrypter);
+
+    return encrypter->R;
+}
+
+pduint32 pdfr_encrypter_get_OU_length(t_encrypter* encrypter) {
+    assert(encrypter);
+
+    return encrypter->OU_length;
+}
+
+const char* pdfr_encrypter_get_O(t_encrypter* encrypter) {
+    assert(encrypter);
+
+    return encrypter->O;
+}
+
+const char* pdfr_encrypter_get_U(t_encrypter* encrypter) {
+    assert(encrypter);
+
+    return encrypter->U;
+}
+
+pduint32 pdfr_encrypter_get_permissions(t_encrypter* encrypter) {
+    assert(encrypter);
+
+    return encrypter->perms;
+}
+
+pdbool pdfr_encrypter_get_metadata_encrypted(t_encrypter* encrypter) {
+    assert(encrypter);
+
+    return encrypter->encrypt_metadata;
+}
+
+PDFRAS_ENCRYPT_ALGORITHM pdfr_encrypter_get_algorithm(t_encrypter* encrypter) {
+    assert(encrypter);
+
+    return encrypter->algorithm;
+}
+
+const char* pdfr_encrypter_get_OE(t_encrypter* encrypter) {
+    assert(encrypter);
+
+    return encrypter->OE;
+}
+
+const char* pdfr_encrypter_get_UE(t_encrypter* encrypter) {
+    assert(encrypter);
+
+    return encrypter->UE;
+}
+
+pduint32 pdfr_encrypter_get_OUE_length(t_encrypter* encrypter) {
+    assert(encrypter);
+
+    return encrypter->OUE_length;
+}
+
+const char* pdfr_encrypter_get_Perms(t_encrypter* encrypter) {
+    assert(encrypter);
+
+    return encrypter->Perms;
+}
+
+pduint32 pdfr_encrypter_get_Perms_length(t_encrypter* encrypter) {
+    assert(encrypter);
+
+    return encrypter->Perms_length;
+}

--- a/pdfras_encryption/pdfras_encryption.def
+++ b/pdfras_encryption/pdfras_encryption.def
@@ -1,0 +1,21 @@
+LIBRARY			pdfras_encryption
+EXPORTS
+	pdfr_create_encrypter						@1
+	pdfr_destroy_encrypter						@2
+	pdfr_encrypter_object_number				@3
+	pdfr_encrypter_dictionary_data  			@4
+	pdfr_encrypter_get_V						@5
+	pdfr_encrypter_get_key_length				@6
+	pdfr_encrypter_get_R						@7
+	pdfr_encrypter_get_OU_length				@8
+	pdfr_encrypter_get_O						@9
+	pdfr_encrypter_get_U						@10
+	pdfr_encrypter_get_permissions				@11
+	pdfr_encrypter_get_metadata_encrypted		@12
+	pdfr_encrypter_get_algorithm				@13
+	pdfr_encrypter_encrypt_data					@14
+	pdfr_encrypter_get_OE						@15
+	pdfr_encrypter_get_UE						@16
+	pdfr_encrypter_get_OUE_length				@17
+	pdfr_encrypter_get_Perms					@18
+	pdfr_encrypter_get_Perms_length				@19

--- a/pdfras_encryption/pdfras_encryption.h
+++ b/pdfras_encryption/pdfras_encryption.h
@@ -1,0 +1,104 @@
+#ifndef _H_PdfRaster_Encryption
+#define _H_PdfRaster_Encryption
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "PdfPlatform.h"
+
+typedef enum {
+    PDFRAS_RC4_40,   // RC4 with encryption key length of 40 bits
+    PDFRAS_RC4_128,  // RC4 with ecnryption key length of 128 bits
+    PDFRAS_AES_128,  // AES with encryption key length of 128 bits
+    PDFRAS_AES_256,  // AES with encryption key lenght of 256 bits
+    PDFRAS_UNDEFINED_ENCRYPT_ALGORITHM
+} PDFRAS_ENCRYPT_ALGORITHM;
+
+typedef enum {
+    PDFRAS_PERM_PRINT_DOCUMENT = 0x00000004,
+    PDFRAS_PERM_MODIFY_DOCUMENT = 0x00000008,
+    PDFRAS_PERM_COPY_FROM_DOCUMENT = 0x00000010,
+    PDFRAS_PERM_EDIT_ANNOTS = 0x00000020,
+    PDFRAS_PERM_FILL_FORMS = 0x00000100,
+    PDFRAS_PERM_ACCESSIBILITY = 0x00000200,
+    PDFRAS_PERM_ASSEMBLE_DOCUMENT = 0x00000400,
+    PDFRAS_PERM_HIGH_PRINT = 0x00000800
+} PDFRAS_PERMS;
+
+typedef struct t_encrypter t_encrypter;
+
+// Creates encrypter
+// user_passwd: open password with enabled restrictions on document
+// owner_password: password for owner of document. Document withour any restrictions.
+// perms: permissions
+// algorithm: algorithm used to encrypt of document
+// metadata: true for encrypting metadata, otherwise false.
+t_encrypter* PDFRASAPICALL pdfr_create_encrypter(const char* user_passwd, const char* owner_passwd, PDFRAS_PERMS perms, PDFRAS_ENCRYPT_ALGORITHM algorithm, pdbool metadata);
+typedef t_encrypter* (PDFRASAPICALL *pfn_pdfr_create_encrypter) (const char* owner_passwd, const char* user_passwd, PDFRAS_PERMS perms, PDFRAS_ENCRYPT_ALGORITHM algorithm, pdbool metadata);
+
+// Destroy encrypter
+void PDFRASAPICALL pdfr_destroy_encrypter(t_encrypter* encrypter);
+typedef void (PDFRASAPICALL *pfn_pdfr_destroy_encrypter) (t_encrypter* encrypter);
+
+// Update object number for actual object to be encrypted
+void PDFRASAPICALL pdfr_encrypter_object_number(t_encrypter* encrypter, pduint32 objnum, pduint32 gennum);
+typedef void (PDFRASAPICALL *pfn_pdfr_encrypter_object_number) (t_encrypter* encrypter, pduint32 objnum, pduint32 gennum);
+
+// Prepares Encrypt dictionary values
+// TODO: rename this function
+pdbool PDFRASAPICALL pdfr_encrypter_dictionary_data(t_encrypter* encrypter, const char* document_id, pduint32 id_len);
+typedef pdbool(PDFRASAPICALL *pfn_pdfr_encrypter_dictionary_data) (t_encrypter* encrypter, const char* document_id, pduint32 id_len);
+
+// Encrypt data
+pdint32 PDFRASAPICALL pdfr_encrypter_encrypt_data(t_encrypter* encrypter, const pduint8* data_in, const pdint32 in_len, pduint8* data_out);
+typedef pdint32(PDFRASAPICALL *pfn_pdfr_encrypter_encrypt_data) (t_encrypter* encrypter, const pduint8* data_in, const pdint32 in_len, pduint8* data_out);
+
+// Query functions
+pduint8 PDFRASAPICALL pdfr_encrypter_get_V(t_encrypter* encrypter);
+typedef pduint8(PDFRASAPICALL *pfn_pdfr_encrypter_get_V) (t_encrypter* encrypter);
+
+pduint32 PDFRASAPICALL pdfr_encrypter_get_key_length(t_encrypter* encrypter);
+typedef pduint32(PDFRASAPICALL *pfn_pdfr_encrypter_get_key_length) (t_encrypter* encrypter);
+
+pduint8 PDFRASAPICALL pdfr_encrypter_get_R(t_encrypter* encrypter);
+typedef pduint8(PDFRASAPICALL *pfn_pdfr_encrypter_get_R) (t_encrypter* encrypter);
+
+pduint32 PDFRASAPICALL pdfr_encrypter_get_OU_length(t_encrypter* encrypter);
+typedef pduint32(PDFRASAPICALL *pfn_pdfr_encrypter_get_OU_length) (t_encrypter* encrypter);
+
+const char* PDFRASAPICALL pdfr_encrypter_get_O(t_encrypter* encrypter);
+typedef const char* (PDFRASAPICALL *pfn_pdfr_encrypter_get_O) (t_encrypter* encrypter);
+
+const char* PDFRASAPICALL pdfr_encrypter_get_U(t_encrypter* encrypter);
+typedef const char* (PDFRASAPICALL *pfn_pdfr_encrypter_get_U) (t_encrypter* encrypter);
+
+pduint32 PDFRASAPICALL pdfr_encrypter_get_permissions(t_encrypter* encrypter);
+typedef pduint32(PDFRASAPICALL *pfn_pdfr_encrypter_get_permissions) (t_encrypter* encrypter);
+
+pdbool PDFRASAPICALL pdfr_encrypter_get_metadata_encrypted(t_encrypter* encrypter);
+typedef pdbool(PDFRASAPICALL *pfn_pdfr_encrypter_get_metadata_encrypted) (t_encrypter* encrypter);
+
+PDFRAS_ENCRYPT_ALGORITHM PDFRASAPICALL pdfr_encrypter_get_algorithm(t_encrypter* encrypter);
+typedef PDFRAS_ENCRYPT_ALGORITHM(PDFRASAPICALL *pfn_pdfr_encrypter_get_algorithm) (t_encrypter* encrypter);
+
+const char* PDFRASAPICALL pdfr_encrypter_get_OE(t_encrypter* encrypter);
+typedef const char* (PDFRASAPICALL pfn_pdfr_encrypter_get_OE) (t_encrypter* encrypter);
+
+const char* PDFRASAPICALL pdfr_encrypter_get_UE(t_encrypter* encrypter);
+typedef const char* (PDFRASAPICALL pfn_pdfr_encrypter_get_UE) (t_encrypter* encrypter);
+
+pduint32 PDFRASAPICALL pdfr_encrypter_get_OUE_length(t_encrypter* encrypter);
+typedef pduint32(PDFRASAPICALL pfn_pdfr_encrypter_get_OUE_length) (t_encrypter* encrypter);
+
+const char* PDFRASAPICALL pdfr_encrypter_get_Perms(t_encrypter* encrypter);
+typedef const char* (PDFRASAPICALL pfn_pdfr_encrypter_get_Perms) (t_encrypter* encrypter);
+
+pduint32 PDFRASAPICALL pdfr_encrypter_get_Perms_length(t_encrypter* encrypter);
+typedef pduint32(PDFRASAPICALL pfn_pdfr_encrypter_get_Perms_length) (t_encrypter* encrypter);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _H_PdfRaster_Encryption

--- a/pdfras_encryption/pdfras_encryption.vcxproj
+++ b/pdfras_encryption/pdfras_encryption.vcxproj
@@ -18,11 +18,23 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="aes_crypter.h" />
+    <ClInclude Include="pdfras_encryption.h" />
+    <ClInclude Include="rc4_crypter.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="aes_crypter.c" />
+    <ClCompile Include="pdfras_encryption.c" />
+    <ClCompile Include="rc4_crypter.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="pdfras_encryption.def" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{B37B7306-E288-4D83-A810-ADF3F53DB542}</ProjectGuid>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <Keyword>ManagedCProj</Keyword>
-    <RootNamespace>pdfras_reader_managed</RootNamespace>
+    <ProjectGuid>{830942A3-B9B6-4BEA-A5AA-213DA65C6E1B}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>pdfras_encryption</RootNamespace>
     <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -31,28 +43,26 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
-    <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
-    <CLRSupport>true</CLRSupport>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
-    <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
-    <CLRSupport>true</CLRSupport>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -87,91 +97,80 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AdditionalIncludeDirectories>..\pdfras_reader;..\pdfras_writer;..\pdfras_encryption;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <TreatWarningAsError>true</TreatWarningAsError>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;PDFRAS_ENCRYPTION_EXPORTS;%(PreprocessorDefinitions);PDFRAS_ENCRYPTION_EXPORTS;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\pdfras_writer;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies />
+      <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\openssl\x86_Debug\lib;..\bin\x86\Debug\</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libcrypto.lib;libssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>pdfras_encryption.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AdditionalIncludeDirectories>..\pdfras_reader;..\pdfras_writer;..\pdfras_encryption;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <TreatWarningAsError>true</TreatWarningAsError>
+      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;PDFRAS_ENCRYPTION_EXPORTS;%(PreprocessorDefinitions);PDFRAS_ENCRYPTION_EXPORTS;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\pdfras_writer;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies />
+      <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\openssl\x64_Debug\lib;..\bin\x64\Debug\</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libcrypto.lib;libssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>pdfras_encryption.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AdditionalIncludeDirectories>..\pdfras_reader;..\pdfras_writer;..\pdfras_encryption;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <TreatWarningAsError>true</TreatWarningAsError>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;PDFRAS_ENCRYPTION_EXPORTS;%(PreprocessorDefinitions);PDFRAS_ENCRYPTION_EXPORTS;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\pdfras_writer;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies />
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\openssl\x86_Release\lib;..\bin\x86\Release\</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libcrypto.lib;libssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>pdfras_encryption.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AdditionalIncludeDirectories>..\pdfras_reader;..\pdfras_writer;..\pdfras_encryption;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <TreatWarningAsError>true</TreatWarningAsError>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;PDFRAS_ENCRYPTION_EXPORTS;%(PreprocessorDefinitions);PDFRAS_ENCRYPTION_EXPORTS;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\pdfras_writer;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies />
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\openssl\x64_Release\lib;..\bin\x64\Release\</AdditionalLibraryDirectories>
+      <AdditionalDependencies>libcrypto.lib;libssl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>pdfras_encryption.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="PdfRasterReader.h" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClCompile Include="..\pdfras_reader\pdfrasread.c">
-      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CompileAsCpp</CompileAs>
-      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">CompileAsCpp</CompileAs>
-      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
-      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">_CRT_SECURE_NO_WARNINGS;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">_CRT_SECURE_NO_WARNINGS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
-    <ClCompile Include="..\pdfras_reader\pdfrasread_files.c">
-      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">CompileAsCpp</CompileAs>
-      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">CompileAsCpp</CompileAs>
-      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
-      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">_CRT_SECURE_NO_WARNINGS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">_CRT_SECURE_NO_WARNINGS;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
-    <ClCompile Include="AssemblyInfo.cpp" />
-    <ClCompile Include="PdfRasterReader.cpp" />
-  </ItemGroup>
-  <ItemGroup>
-    <Text Include="ReadMe.txt" />
-  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/pdfras_encryption/pdfras_encryption.vcxproj.filters
+++ b/pdfras_encryption/pdfras_encryption.vcxproj.filters
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pdfras_encryption.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="rc4_crypter.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="aes_crypter.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pdfras_encryption.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="rc4_crypter.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="aes_crypter.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="pdfras_encryption.def">
+      <Filter>Source Files</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/pdfras_encryption/pdfras_encryption.vcxproj.user
+++ b/pdfras_encryption/pdfras_encryption.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/pdfras_encryption/rc4_crypter.c
+++ b/pdfras_encryption/rc4_crypter.c
@@ -1,0 +1,17 @@
+// rc4_crypter.c - encrypt/decrypt data using RC4 cipher
+
+#include "rc4_crypter.h"
+
+#include "openssl/rc4.h"
+
+pduint32 pdfras_rc4_encrypt_data(const char* key, const pduint32 key_len, const char* data_in, const pdint32 in_len, char* data_out) {
+    if (data_in == NULL || data_out == NULL)
+        return -1;
+
+    RC4_KEY rc4_key;
+    RC4_set_key(&rc4_key, key_len, key);
+
+    RC4(&rc4_key, in_len, data_in, data_out);
+
+    return in_len;
+}

--- a/pdfras_encryption/rc4_crypter.h
+++ b/pdfras_encryption/rc4_crypter.h
@@ -1,0 +1,16 @@
+#ifndef _H_Rc4Crypter
+#define _H_Rc4Crypter
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "PdfPlatform.h"
+
+extern pduint32 pdfras_rc4_encrypt_data(const char* key, const pduint32 key_len, const char* data_in, const pdint32 in_len, char* data_out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _H_Rc4Crypter

--- a/pdfras_writer/PdfDigitalSignature.h
+++ b/pdfras_writer/PdfDigitalSignature.h
@@ -34,6 +34,9 @@ pdbool digitalsignature_written(t_pdfdigitalsignature* signature);
 // internal handler for writer
 int digitalsignature_writer(const pduint8* data, pduint32 offset, pduint32 len, void* cookie);
 
+// get digital signature dictionary object number
+extern pduint32 pd_digitalsignature_digsig_objnum(t_pdfdigitalsignature* signature);
+
 #ifdef __cplusplus
 }
 #endif

--- a/pdfras_writer/PdfRaster.c
+++ b/pdfras_writer/PdfRaster.c
@@ -151,6 +151,8 @@ t_pdfrasencoder* pdfr_signed_encoder_create(int apiLevel, t_OS* os, const char* 
     
     pd_write_pdf_header(enc->stm, "1.7");
 
+    pd_outstream_set_digitalsignature(enc->stm, enc->signer);
+
     return enc;
 }
 

--- a/pdfras_writer/PdfRaster.h
+++ b/pdfras_writer/PdfRaster.h
@@ -8,6 +8,7 @@ extern "C" {
 #include "PdfAlloc.h"
 #include "PdfValues.h"
 #include "PdfDatasink.h"
+#include "pdfras_encryption.h"
 
 #define PDFRAS_API_LEVEL	1
 
@@ -258,6 +259,23 @@ typedef void (PDFRASAPICALL *pfn_digitalsignature_set_location) (t_pdfdigitalsig
 // Set contact info for signer
 void PDFRASAPICALL pdfr_digitalsignature_set_contactinfo(t_pdfdigitalsignature* signature, const char* contactinfo);
 typedef void (PDFRASAPICALL *pfn_digitalsignature_set_contactinfo) (t_pdfdigitalsignature* signature, const char* contactinfo);
+
+/* Encryption prototypes */
+// RC4 40 bits
+void PDFRASAPICALL pdfr_encoder_set_RC4_40_encrypter(t_pdfrasencoder* enc, const char* user_password, const char* owner_password, PDFRAS_PERMS perms, pdbool metadata);
+typedef void (PDFRASAPICALL *pfn_pdfr_encoder_set_RC4_40_encrypter) (t_pdfrasencoder* enc, const char* user_password, const char* owner_password, pdint32 perms, pdbool metadata);
+
+// RC4 128 bits
+void PDFRASAPICALL pdfr_encoder_set_RC4_128_encrypter(t_pdfrasencoder* enc, const char* user_password, const char* owner_password, PDFRAS_PERMS perms, pdbool metadata);
+typedef void (PDFRASAPICALL *pfn_pdfr_encoder_set_RC4_128_encrypter) (t_pdfrasencoder* enc, const char* user_password, const char* owner_password, pdint32 perms, pdbool metadata);
+
+// AES 128 bits
+void PDFRASAPICALL pdfr_encoder_set_AES128_encrypter(t_pdfrasencoder* enc, const char* user_password, const char* owner_password, PDFRAS_PERMS perms, pdbool metadata);
+typedef void (PDFRASAPICALL *pfn_pdfr_encoder_set_AES128_encrypter) (t_pdfrasencoder* enc, const char* user_password, const char* owner_password, pdint32 perms, pdbool metadata);
+
+// AES 256 bits
+void PDFRASAPICALL pdfr_encoder_set_AES256_encrypter(t_pdfrasencoder* enc, const char* user_password, const char* owner_password, PDFRAS_PERMS perms, pdbool metadata);
+typedef void (PDFRASAPICALL *pfn_pdfr_encoder_set_AES256_encrypter) (t_pdfrasencoder* enc, const char* user_password, const char* owner_password, pdint32 perms, pdbool metadata);
 
 #ifdef __cplusplus
 }

--- a/pdfras_writer/PdfSecurityHandler.c
+++ b/pdfras_writer/PdfSecurityHandler.c
@@ -27,6 +27,7 @@ struct t_pdencrypter {
 
     pduint32 encrypt_obj_number;
     pduint32 digsig_obj_number;
+    pduint32 current_obj_number;
 
     pdbool active;
 };
@@ -40,6 +41,7 @@ t_pdencrypter* pd_encrypt_new(t_pdmempool* pool, const char* user_passwd, const 
     crypter->pool = pool;
     crypter->digsig_obj_number = 0;
     crypter->encrypt_obj_number = 0;
+    crypter->current_obj_number = 0;
     crypter->active = PD_TRUE;
 
     crypter->data = (t_writer_data*)pd_alloc(crypter->pool, sizeof(t_writer_data));
@@ -84,6 +86,7 @@ void pd_encrypt_start_object(t_pdencrypter *crypter, pduint32 onr, pduint32 gen)
             pd_encrypt_activate(crypter);
 
         pdfr_encrypter_object_number(crypter->encrypter, onr, gen);
+        crypter->current_obj_number = onr;
     }
 }
 
@@ -232,4 +235,10 @@ void pd_encrypt_writer_reset(t_pdencrypter* encrypter) {
         encrypter->data->bufferSize = BUFFER_SIZE;
         encrypter->data->written = 0;
     }
+}
+
+int pd_encrypt_get_current_objectnumber(t_pdencrypter* encrypter) {
+    assert(encrypter);
+
+    return encrypter->current_obj_number;
 }

--- a/pdfras_writer/PdfSecurityHandler.c
+++ b/pdfras_writer/PdfSecurityHandler.c
@@ -1,45 +1,235 @@
+#include <assert.h>
+#include <string.h>
+
 #include "PdfSecurityHandler.h"
 #include "PdfAlloc.h"
+#include "PdfDict.h"
+#include "PdfString.h"
+#include "PdfStandardAtoms.h"
+#include "pdfras_encryption.h"
+#include "PdfXrefTable.h"
+
+#define BUFFER_SIZE 8192
+
+typedef struct {
+    pduint8* buffer;
+    pduint32 bufferSize;
+    pduint32 written;
+} t_writer_data;
 
 struct t_pdencrypter {
-	void*		cookie;			// data specific to a particular class of encrypter
-	pduint32	onr, gen;		// number & generation of current object
+	t_pdmempool* pool;
+    fOutputWriter userWriter;
+    void* userCookie;
+    t_writer_data* data;
+
+    t_encrypter* encrypter;
+
+    pduint32 encrypt_obj_number;
+    pduint32 digsig_obj_number;
+
+    pdbool active;
 };
 
-t_pdencrypter* pd_encrypt_new(t_pdmempool* pool, void *cookie)
+t_pdencrypter* pd_encrypt_new(t_pdmempool* pool, const char* user_passwd, const char* owner_passwd, PDFRAS_PERMS perms, PDFRAS_ENCRYPT_ALGORITHM algoritm, pdbool encrypt_metada, const char* document_id, pdint32 id_len)
 {
 	t_pdencrypter* crypter = (t_pdencrypter*)pd_alloc(pool, sizeof(t_pdencrypter));
-	if (crypter) {
-		crypter->cookie = cookie;
-	}
+    if (!crypter)
+        return NULL;
+
+    crypter->pool = pool;
+    crypter->digsig_obj_number = 0;
+    crypter->encrypt_obj_number = 0;
+    crypter->active = PD_TRUE;
+
+    crypter->data = (t_writer_data*)pd_alloc(crypter->pool, sizeof(t_writer_data));
+
+    crypter->data->buffer = (pduint8*)pd_alloc(crypter->pool, sizeof(pduint8) * BUFFER_SIZE);
+    if (!crypter->data->buffer)
+        return NULL;
+
+    crypter->data->bufferSize = BUFFER_SIZE;
+    crypter->data->written = 0;
+
+
+    crypter->encrypter = pdfr_create_encrypter(user_passwd, owner_passwd, perms, algoritm, encrypt_metada);
+    pdfr_encrypter_dictionary_data(crypter->encrypter, document_id, id_len);
 	return crypter;
 }
 
 void pd_encrypt_free(t_pdencrypter* crypter)
 {
+    if (crypter->encrypter)
+        pdfr_destroy_encrypter(crypter->encrypter);
+
 	pd_free(crypter);
+}
+
+void pd_encrypt_dictionary(t_pdencrypter* crypter, t_pdxref* xref, t_pdvalue* trailer) {
+    t_pdvalue encrypt_dict = pd_dict_new(crypter->pool, 4);
+    // fill encryption dictionary
+    pd_encrypt_fill_dictionary(crypter, &encrypt_dict);
+    t_pdvalue encrypt_dict_ref = pd_xref_makereference(xref, encrypt_dict);
+    pd_dict_put(*trailer, ((t_pdatom) "Encrypt"), encrypt_dict_ref);
+
+    crypter->encrypt_obj_number = pd_reference_object_number(encrypt_dict_ref);
 }
 
 void pd_encrypt_start_object(t_pdencrypter *crypter, pduint32 onr, pduint32 gen)
 {
-	crypter->onr = onr;
-	crypter->gen = gen;
+    if (crypter->encrypt_obj_number == onr)
+        pd_encrypt_deactivate(crypter);
+    else {
+        if (pd_encrypt_is_active(crypter) == PD_FALSE)
+            pd_encrypt_activate(crypter);
+
+        pdfr_encrypter_object_number(crypter->encrypter, onr, gen);
+    }
 }
 
-pduint32 pd_encrypted_size(t_pdencrypter *crypter, pduint32 n)\
+pdint32 pd_encrypted_size(t_pdencrypter *crypter, const pduint8* data, const pdint32 data_len)
 {
-	(void)crypter;
-	// for our supported encryptions, output size = input size.
-	return n;
+    return pdfr_encrypter_encrypt_data(crypter->encrypter, data, data_len, NULL);
 }
 
-void pd_encrypt_data(t_pdencrypter *crypter, pduint8 *outbuf, const pduint8* data, pduint32 n)
+pdint32 pd_encrypt_data(t_pdencrypter *crypter, const pduint8* data_in, const pdint32 in_len, pduint8* data_out)
 {
-	(void)crypter;
-	(void)data;
-	pduint32 i;
-	for (i = 0; i < n; i++) {
-		outbuf[i] = '$';		// TODO: real encryption...
-	}
+    return pdfr_encrypter_encrypt_data(crypter->encrypter, data_in, in_len, data_out);
 }
 
+void pd_encrypt_fill_dictionary(t_pdencrypter* encrypter, t_pdvalue* dict) {
+    pd_dict_put(*dict, ((t_pdatom) "Filter"), pdatomvalue((t_pdatom)"Standard"));
+
+    pduint8 V = pdfr_encrypter_get_V(encrypter->encrypter);
+    pd_dict_put(*dict, ((t_pdatom)"V"), pdintvalue(V));
+    
+    pduint32 key_length = pdfr_encrypter_get_key_length(encrypter->encrypter);
+    pd_dict_put(*dict, ((t_pdatom) "Length"), pdintvalue(key_length));
+
+    pduint8 R = pdfr_encrypter_get_R(encrypter->encrypter);
+    pd_dict_put(*dict, ((t_pdatom) "R"), pdintvalue(R));
+
+    pduint32 ou_length = pdfr_encrypter_get_OU_length(encrypter->encrypter);
+    const char* O = pdfr_encrypter_get_O(encrypter->encrypter);
+    const char* U = pdfr_encrypter_get_U(encrypter->encrypter);
+    pd_dict_put(*dict, ((t_pdatom) "O"), pdstringvalue(pd_string_new_binary(encrypter->pool, ou_length, O)));
+    pd_dict_put(*dict, ((t_pdatom) "U"), pdstringvalue(pd_string_new_binary(encrypter->pool, ou_length, U)));
+    
+    pduint32 P = pdfr_encrypter_get_permissions(encrypter->encrypter);
+    pd_dict_put(*dict, ((t_pdatom) "P"), pdintvalue(P));
+
+    if (V == 4 || V == 5) {
+        pdbool metadata_ecnrytped = pdfr_encrypter_get_metadata_encrypted(encrypter->encrypter);
+        pd_dict_put(*dict, ((t_pdatom) "EncryptMetadata"), pdboolvalue(metadata_ecnrytped));
+
+        t_pdvalue cf_dict = pd_dict_new(encrypter->pool, 1);
+        t_pdvalue stdcf_dict = pd_dict_new(encrypter->pool, 4);
+
+        pd_dict_put(stdcf_dict, ((t_pdatom) "Type"), pdatomvalue((t_pdatom) "CryptFilter"));
+        PDFRAS_ENCRYPT_ALGORITHM algorithm = pdfr_encrypter_get_algorithm(encrypter->encrypter);
+
+        if (algorithm == PDFRAS_AES_128)
+            pd_dict_put(stdcf_dict, ((t_pdatom) "CFM"), pdatomvalue((t_pdatom) "AESV2"));
+        if (algorithm == PDFRAS_RC4_128)
+            pd_dict_put(stdcf_dict, ((t_pdatom) "CFM"), pdatomvalue((t_pdatom) "V2"));
+        if (algorithm == PDFRAS_AES_256)
+            pd_dict_put(stdcf_dict, ((t_pdatom) "CFM"), pdatomvalue((t_pdatom) "AESV3"));
+
+        pd_dict_put(stdcf_dict, ((t_pdatom) "AuthEvent"), pdatomvalue((t_pdatom) "DocOpen"));
+        pd_dict_put(stdcf_dict, ((t_pdatom) "Length"), pdintvalue(key_length / 8));
+
+        pd_dict_put(cf_dict, ((t_pdatom) "StdCF"), stdcf_dict);
+        pd_dict_put(*dict, ((t_pdatom) "CF"), cf_dict);
+        pd_dict_put(*dict, ((t_pdatom) "StrF"), pdatomvalue((t_pdatom) "StdCF"));
+        pd_dict_put(*dict, ((t_pdatom) "StmF"), pdatomvalue((t_pdatom) "StdCF"));
+    }
+
+    if (R == 6) {
+        const char* OE = pdfr_encrypter_get_OE(encrypter->encrypter);
+        const char* UE = pdfr_encrypter_get_UE(encrypter->encrypter);
+        const char* Perms = pdfr_encrypter_get_Perms(encrypter->encrypter);
+        pduint32 oue_length = pdfr_encrypter_get_OUE_length(encrypter->encrypter);
+        pduint32 Perms_length = pdfr_encrypter_get_Perms_length(encrypter->encrypter);
+
+        pd_dict_put(*dict, ((t_pdatom) "OE"), pdstringvalue(pd_string_new_binary(encrypter->pool, oue_length, OE)));
+        pd_dict_put(*dict, ((t_pdatom) "UE"), pdstringvalue(pd_string_new_binary(encrypter->pool, oue_length, UE)));
+        pd_dict_put(*dict, ((t_pdatom) "Perms"), pdstringvalue(pd_string_new_binary(encrypter->pool, Perms_length, Perms)));
+    }
+}
+
+void pd_encrypt_activate(t_pdencrypter* encrypter) {
+    if (encrypter)
+        encrypter->active = PD_TRUE;
+}
+
+void pd_encrypt_deactivate(t_pdencrypter* encrypter) {
+    if (encrypter)
+        encrypter->active = PD_FALSE;
+}
+
+pdbool pd_encrypt_is_active(t_pdencrypter* encrypter) {
+    if (encrypter)
+        return encrypter->active;
+
+    return PD_FALSE;
+}
+
+pdbool pd_encrypt_metadata(t_pdencrypter* encrypter) {
+    if (!encrypter)
+        return PD_FALSE;
+
+    return pdfr_encrypter_get_metadata_encrypted(encrypter->encrypter);
+}
+
+// callback for writing data during encryption.
+// Becuase pdfras writes stream byte by byte we have to collect whole stream and encrypt it.
+int pd_encrypt_writer(const pduint8* data, pduint32 offset, pduint32 len, void* cookie) {
+    assert(cookie);
+
+    if (!data || !len)
+        return 0;
+
+    data += offset;
+
+    t_pdencrypter* encrypter = (t_pdencrypter*)cookie;
+
+    if ((encrypter->data->written + len) > encrypter->data->bufferSize) {
+        pduint32 size = encrypter->data->written + len;
+        pduint8* buf = (pduint8*)pd_alloc(encrypter->pool, sizeof(pduint8) * size);
+
+        if (!buf)
+            return 0;
+
+        memcpy(buf, encrypter->data->buffer, encrypter->data->written);
+        pd_free(encrypter->data->buffer);
+        encrypter->data->buffer = buf;
+        encrypter->data->bufferSize = size;
+    }
+
+    memcpy(encrypter->data->buffer + encrypter->data->written, data, len);
+    encrypter->data->written += len;
+
+    return len;
+}
+
+pduint8* pd_encrypt_writer_data(t_pdencrypter* encrypter) {
+    assert(encrypter);
+
+    return encrypter->data->buffer;
+}
+pduint32 pd_encrypt_writer_data_len(t_pdencrypter* encrypter) {
+    assert(encrypter);
+
+    return encrypter->data->written;
+}
+
+void pd_encrypt_writer_reset(t_pdencrypter* encrypter) {
+    assert(encrypter);
+
+    if (encrypter->data->buffer) {
+        pd_free(encrypter->data->buffer);
+        encrypter->data->buffer = (pduint8*)pd_alloc(encrypter->pool, sizeof(pduint8) * BUFFER_SIZE);
+        encrypter->data->bufferSize = BUFFER_SIZE;
+        encrypter->data->written = 0;
+    }
+}

--- a/pdfras_writer/PdfSecurityHandler.h
+++ b/pdfras_writer/PdfSecurityHandler.h
@@ -50,6 +50,9 @@ extern pduint8* pd_encrypt_writer_data(t_pdencrypter* encrypter);
 extern pduint32 pd_encrypt_writer_data_len(t_pdencrypter* encrypter);
 extern void pd_encrypt_writer_reset(t_pdencrypter* encrypter);
 
+// Current object number being encrypted
+extern int pd_encrypt_get_current_objectnumber(t_pdencrypter* encrypter);
+
 #ifdef __cplusplus
 }
 #endif

--- a/pdfras_writer/PdfSecurityHandler.h
+++ b/pdfras_writer/PdfSecurityHandler.h
@@ -1,10 +1,24 @@
 #ifndef _H_PdfSecurityHandler
 #define _H_PdfSecurityHandler
-#pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//#include "PdfXrefTable.h"
+#include "pdfras_encryption.h"
 #include "PdfOS.h"
+#include "PdfValues.h"
 
 typedef struct t_pdencrypter t_pdencrypter;
+
+// Create a new encrytper.
+extern t_pdencrypter* pd_encrypt_new(t_pdmempool* pool, const char* user_passwd, const char* owner_passwd, PDFRAS_PERMS perms, PDFRAS_ENCRYPT_ALGORITHM algoritm, pdbool encrypt_metada, const char* document_id, pdint32 id_len);
+
+// free encrypter
+extern void pd_encrypt_free(t_pdencrypter* crypter);
+
+extern void pd_encrypt_dictionary(t_pdencrypter* crypter, t_pdxref* xref, t_pdvalue* trailer);
 
 // functions associated with an (encryption) security handler:
 // * Creating an encryption state for a PDF from whatever it needs as input
@@ -18,9 +32,26 @@ typedef struct t_pdencrypter t_pdencrypter;
 extern void pd_encrypt_start_object(t_pdencrypter *crypter, pduint32 onr, pduint32 genr);
 
 // calculate the encrypted size of n bytes of plain data
-extern pduint32 pd_encrypted_size(t_pdencrypter *crypter, pduint32 n);
+extern pdint32 pd_encrypted_size(t_pdencrypter *crypter, const pduint8* data, const pdint32 data_len);
 
 // encrypt n bytes of data
-extern void pd_encrypt_data(t_pdencrypter *crypter, pduint8 *outbuf, const pduint8* data, pduint32 n);
+extern pdint32 pd_encrypt_data(t_pdencrypter *crypter, const pduint8* data_in, const pdint32 in_len, pduint8* data_out);
+
+extern void pd_encrypt_fill_dictionary(t_pdencrypter* encrypter, t_pdvalue* dict);
+
+extern void pd_encrypt_activate(t_pdencrypter* encrypter);
+extern void pd_encrypt_deactivate(t_pdencrypter* encrypter);
+extern pdbool pd_encrypt_is_active(t_pdencrypter* encrypter);
+extern pdbool pd_encrypt_metadata(t_pdencrypter* encrypter);
+
+// Our callback for collecting stream data
+extern int pd_encrypt_writer(const pduint8* data, pduint32 offset, pduint32 len, void* cookie);
+extern pduint8* pd_encrypt_writer_data(t_pdencrypter* encrypter);
+extern pduint32 pd_encrypt_writer_data_len(t_pdencrypter* encrypter);
+extern void pd_encrypt_writer_reset(t_pdencrypter* encrypter);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/pdfras_writer/PdfStreaming.h
+++ b/pdfras_writer/PdfStreaming.h
@@ -11,6 +11,7 @@
 #include "PdfAlloc.h"
 #include "PdfValues.h"
 #include "PdfSecurityHandler.h"
+#include "PdfDigitalSignature.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -118,6 +119,9 @@ extern fOutputWriter pd_outputstream_set_writer(t_pdoutstream* stm, fOutputWrite
 // Set cookie for writer handler
 // Return previous stored cookie
 extern void* pd_outputstream_set_cookie(t_pdoutstream* stm, void* cookie);
+
+// Set digital signature object
+extern void pd_outstream_set_digitalsignature(t_pdoutstream* stm, t_pdfdigitalsignature* signature);
 
 #ifdef __cplusplus
 }

--- a/pdfras_writer/pdfras_writer.vcxproj
+++ b/pdfras_writer/pdfras_writer.vcxproj
@@ -96,13 +96,13 @@
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <AdditionalIncludeDirectories>..\pdfras_digitalsignature;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\pdfras_digitalsignature;..\pdfras_encryption;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ModuleDefinitionFile>pdfraswrite.def</ModuleDefinitionFile>
-      <AdditionalDependencies>pdfras_digitalsignature.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>pdfras_digitalsignature.lib;pdfras_encryption.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\bin\x86\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
@@ -123,13 +123,13 @@
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <AdditionalIncludeDirectories>..\pdfras_digitalsignature;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\pdfras_digitalsignature;..\pdfras_encryption;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ModuleDefinitionFile>pdfraswrite.def</ModuleDefinitionFile>
-      <AdditionalDependencies>pdfras_digitalsignature.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>pdfras_digitalsignature.lib;pdfras_encryption.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\bin\x64\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
@@ -150,7 +150,7 @@
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
       <Optimization>MinSpace</Optimization>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <AdditionalIncludeDirectories>..\pdfras_digitalsignature;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\pdfras_digitalsignature;..\pdfras_encryption;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -158,7 +158,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <ModuleDefinitionFile>pdfraswrite.def</ModuleDefinitionFile>
-      <AdditionalDependencies>pdfras_digitalsignature.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>pdfras_digitalsignature.lib;pdfras_encryption.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\bin\x86\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
@@ -179,7 +179,7 @@
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
       <Optimization>MinSpace</Optimization>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <AdditionalIncludeDirectories>..\pdfras_digitalsignature;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\pdfras_digitalsignature;..\pdfras_encryption;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -187,7 +187,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <ModuleDefinitionFile>pdfraswrite.def</ModuleDefinitionFile>
-      <AdditionalDependencies>pdfras_digitalsignature.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>pdfras_digitalsignature.lib;pdfras_encryption.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\bin\x64\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>

--- a/pdfras_writer/pdfraswrite.def
+++ b/pdfras_writer/pdfraswrite.def
@@ -35,6 +35,11 @@ EXPORTS
 	pdfr_digitalsignature_set_location	@44
 	pdfr_digitalsignature_set_contactinfo @45
 	
+	pdfr_encoder_set_RC4_40_encrypter	@60
+	pdfr_encoder_set_RC4_128_encrypter	@61
+	pdfr_encoder_set_AES128_encrypter	@62
+	pdfr_encoder_set_AES256_encrypter	@63
+	
 	pd_outstream_new				@100
 	pd_outstream_free				@101
 	pd_outstream_set_encrypter			@102

--- a/pdfras_writer_managed/PdfRasterWriter.cpp
+++ b/pdfras_writer_managed/PdfRasterWriter.cpp
@@ -218,6 +218,66 @@ namespace PdfRasterWriter {
         return idx;
     }
 
+    void Writer::encoder_set_RC4_40_encrypter(int idx, String^ user_password, String^ owner_password, PDFRAS_PERMS perms, pdbool metadata) {
+        LOG(fprintf(fp, "> idx=%d", idx));
+        checkStateValid(idx);
+
+        const char* userpwd = (const char*)(Marshal::StringToHGlobalAnsi(user_password)).ToPointer();
+        const char* ownerpwd = (const char*)(Marshal::StringToHGlobalAnsi(owner_password)).ToPointer();
+
+        pdfr_encoder_set_RC4_40_encrypter(state[idx].enc, userpwd, ownerpwd, perms, metadata);
+
+        Marshal::FreeHGlobal(IntPtr((void*)userpwd));
+        Marshal::FreeHGlobal(IntPtr((void*)ownerpwd));
+
+        LOG(fprintf(fp, "<"));
+    }
+
+    void Writer::encoder_set_RC4_128_encrypter(int idx, String^ user_password, String^ owner_password, PDFRAS_PERMS perms, pdbool metadata) {
+        LOG(fprintf(fp, "> idx=%d", idx));
+        checkStateValid(idx);
+
+        const char* userpwd = (const char*)(Marshal::StringToHGlobalAnsi(user_password)).ToPointer();
+        const char* ownerpwd = (const char*)(Marshal::StringToHGlobalAnsi(owner_password)).ToPointer();
+
+        pdfr_encoder_set_RC4_128_encrypter(state[idx].enc, userpwd, ownerpwd, perms, metadata);
+
+        Marshal::FreeHGlobal(IntPtr((void*)userpwd));
+        Marshal::FreeHGlobal(IntPtr((void*)ownerpwd));
+
+        LOG(fprintf(fp, "<"));
+    }
+
+    void Writer::encoder_set_AES128_encrypter(int idx, String^ user_password, String^ owner_password, PDFRAS_PERMS perms, pdbool metadata) {
+        LOG(fprintf(fp, "> idx=%d", idx));
+        checkStateValid(idx);
+
+        const char* userpwd = (const char*)(Marshal::StringToHGlobalAnsi(user_password)).ToPointer();
+        const char* ownerpwd = (const char*)(Marshal::StringToHGlobalAnsi(owner_password)).ToPointer();
+
+        pdfr_encoder_set_AES128_encrypter(state[idx].enc, userpwd, ownerpwd, perms, metadata);
+
+        Marshal::FreeHGlobal(IntPtr((void*)userpwd));
+        Marshal::FreeHGlobal(IntPtr((void*)ownerpwd));
+
+        LOG(fprintf(fp, "<"));
+    }
+
+    void Writer::encoder_set_AES256_encrypter(int idx, String^ user_password, String^ owner_password, PDFRAS_PERMS perms, pdbool metadata) {
+        LOG(fprintf(fp, "> idx=%d", idx));
+        checkStateValid(idx);
+
+        const char* userpwd = (const char*)(Marshal::StringToHGlobalAnsi(user_password)).ToPointer();
+        const char* ownerpwd = (const char*)(Marshal::StringToHGlobalAnsi(owner_password)).ToPointer();
+
+        pdfr_encoder_set_AES256_encrypter(state[idx].enc, userpwd, ownerpwd, perms, metadata);
+
+        Marshal::FreeHGlobal(IntPtr((void*)userpwd));
+        Marshal::FreeHGlobal(IntPtr((void*)ownerpwd));
+
+        LOG(fprintf(fp, "<"));
+    }
+
 	void Writer::encoder_set_creator(int idx, String^ creator)
 	{
 		LOG(fprintf(fp, "> idx=%d", idx));

--- a/pdfras_writer_managed/PdfRasterWriter.h
+++ b/pdfras_writer_managed/PdfRasterWriter.h
@@ -45,6 +45,10 @@ namespace PdfRasterWriter {
 	public:
 		int  encoder_create(int apiLevel, String^ pdfFileName);
         int  encoder_create_digigally_signed(int apiLevel, String^ pdfFileName, String^ pfxFile, String^ password);
+        void encoder_set_RC4_40_encrypter(int idx, String^ user_password, String^ owner_password, PDFRAS_PERMS perms, pdbool metadata);
+        void encoder_set_RC4_128_encrypter(int idx, String^ user_password, String^ owner_password, PDFRAS_PERMS perms, pdbool metadata);
+        void encoder_set_AES128_encrypter(int idx, String^ user_password, String^ owner_password, PDFRAS_PERMS perms, pdbool metadata);
+        void encoder_set_AES256_encrypter(int idx, String^ user_password, String^ owner_password, PDFRAS_PERMS perms, pdbool metadata);
 		void encoder_set_creator(int enc, String^ creator);
 		void encoder_set_resolution(int enc, double xdpi, double ydpi);
 		void encoder_set_pixelformat(int enc, PdfRasterPixelFormat format);

--- a/pdfras_writer_managed/pdfras_writer_managed.vcxproj
+++ b/pdfras_writer_managed/pdfras_writer_managed.vcxproj
@@ -92,11 +92,11 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AdditionalIncludeDirectories>..\pdfras_writer;..\pdfras_digitalsignature;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\pdfras_encryption;..\pdfras_writer;..\pdfras_digitalsignature;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>false</TreatWarningAsError>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>pdfras_digitalsignature.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>pdfras_digitalsignature.lib;pdfras_encryption.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>..\bin\x86\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
@@ -107,11 +107,11 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AdditionalIncludeDirectories>..\pdfras_writer;..\pdfras_digitalsignature;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\pdfras_encryption;..\pdfras_writer;..\pdfras_digitalsignature;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>false</TreatWarningAsError>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>pdfras_digitalsignature.lib;</AdditionalDependencies>
+      <AdditionalDependencies>pdfras_digitalsignature.lib;pdfras_encryption.lib;</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>..\bin\x64\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
@@ -121,11 +121,11 @@
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AdditionalIncludeDirectories>..\pdfras_writer;..\pdfras_digitalsignature;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\pdfras_encryption;..\pdfras_writer;..\pdfras_digitalsignature;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>false</TreatWarningAsError>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>pdfras_digitalsignature.lib;</AdditionalDependencies>
+      <AdditionalDependencies>pdfras_digitalsignature.lib;pdfras_encryption.lib;</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\bin\x86\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -134,11 +134,11 @@
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AdditionalIncludeDirectories>..\pdfras_writer;..\pdfras_digitalsignature;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\pdfras_encryption;..\pdfras_writer;..\pdfras_digitalsignature;..\openssl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>false</TreatWarningAsError>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>pdfras_digitalsignature.lib;</AdditionalDependencies>
+      <AdditionalDependencies>pdfras_digitalsignature.lib;pdfras_encryption.lib;</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\bin\x64\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>

--- a/pdfras_writer_tests/pdfras_writer_tests.vcxproj
+++ b/pdfras_writer_tests/pdfras_writer_tests.vcxproj
@@ -82,7 +82,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_reader;$(SolutionDir)common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_reader;$(SolutionDir)common;..\pdfras_encryption</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
@@ -98,7 +98,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_reader;$(SolutionDir)common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_reader;$(SolutionDir)common;..\pdfras_encryption</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
@@ -116,7 +116,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_reader;$(SolutionDir)common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_reader;$(SolutionDir)common;..\pdfras_encryption</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
@@ -136,7 +136,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_reader;$(SolutionDir)common</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_reader;$(SolutionDir)common;..\pdfras_encryption</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
@@ -168,6 +168,9 @@
   <ItemGroup>
     <ProjectReference Include="..\pdfras_digitalsignature\pdfras_digitalsignature.vcxproj">
       <Project>{ad94958a-b236-416c-b217-2bad5ecf7cc3}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\pdfras_encryption\pdfras_encryption.vcxproj">
+      <Project>{830942a3-b9b6-4bea-a5aa-213da65c6e1b}</Project>
     </ProjectReference>
     <ProjectReference Include="..\pdfras_writer\pdfras_writer.vcxproj">
       <Project>{f96f701b-73f9-4bab-ba84-ceff8a112289}</Project>

--- a/pdfraster.sln
+++ b/pdfraster.sln
@@ -7,6 +7,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pdfras_writer", "pdfras_wri
 	ProjectSection(ProjectDependencies) = postProject
 		{AD5F3A73-01AD-43E9-AE82-427840AE23A2} = {AD5F3A73-01AD-43E9-AE82-427840AE23A2}
 		{AD94958A-B236-416C-B217-2BAD5ECF7CC3} = {AD94958A-B236-416C-B217-2BAD5ECF7CC3}
+		{830942A3-B9B6-4BEA-A5AA-213DA65C6E1B} = {830942A3-B9B6-4BEA-A5AA-213DA65C6E1B}
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pdfras_reader", "pdfras_reader\pdfras_reader.vcxproj", "{C06A94CA-439B-4C91-9FA3-F9C2E3487473}"
@@ -51,6 +52,8 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pdfras_tool", "pdfras_tool\pdfras_tool.vcxproj", "{69D574B2-9F49-456C-8886-C9A7C7482E3A}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pdfras_digitalsignature", "pdfras_digitalsignature\pdfras_digitalsignature.vcxproj", "{AD94958A-B236-416C-B217-2BAD5ECF7CC3}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pdfras_encryption", "pdfras_encryption\pdfras_encryption.vcxproj", "{830942A3-B9B6-4BEA-A5AA-213DA65C6E1B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -182,6 +185,16 @@ Global
 		{AD94958A-B236-416C-B217-2BAD5ECF7CC3}.Release|x64.Build.0 = Release|x64
 		{AD94958A-B236-416C-B217-2BAD5ECF7CC3}.Release|x86.ActiveCfg = Release|Win32
 		{AD94958A-B236-416C-B217-2BAD5ECF7CC3}.Release|x86.Build.0 = Release|Win32
+		{830942A3-B9B6-4BEA-A5AA-213DA65C6E1B}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{830942A3-B9B6-4BEA-A5AA-213DA65C6E1B}.Debug|x64.ActiveCfg = Debug|x64
+		{830942A3-B9B6-4BEA-A5AA-213DA65C6E1B}.Debug|x64.Build.0 = Debug|x64
+		{830942A3-B9B6-4BEA-A5AA-213DA65C6E1B}.Debug|x86.ActiveCfg = Debug|Win32
+		{830942A3-B9B6-4BEA-A5AA-213DA65C6E1B}.Debug|x86.Build.0 = Debug|Win32
+		{830942A3-B9B6-4BEA-A5AA-213DA65C6E1B}.Release|Any CPU.ActiveCfg = Release|Win32
+		{830942A3-B9B6-4BEA-A5AA-213DA65C6E1B}.Release|x64.ActiveCfg = Release|x64
+		{830942A3-B9B6-4BEA-A5AA-213DA65C6E1B}.Release|x64.Build.0 = Release|x64
+		{830942A3-B9B6-4BEA-A5AA-213DA65C6E1B}.Release|x86.ActiveCfg = Release|Win32
+		{830942A3-B9B6-4BEA-A5AA-213DA65C6E1B}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -197,5 +210,6 @@ Global
 		{943AD428-4D74-49AA-807C-36D854FA7723} = {121036C4-905A-4B8E-AC1D-A26BCD0985BD}
 		{34032D75-96A8-43EE-ADBF-F2B68AA4218D} = {D9567C23-AE7B-454A-A06B-74F397A27DF2}
 		{B37B7306-E288-4D83-A810-ADF3F53DB542} = {121036C4-905A-4B8E-AC1D-A26BCD0985BD}
+		{830942A3-B9B6-4BEA-A5AA-213DA65C6E1B} = {1CBDE3D8-0C71-409E-AF14-FBD9988212C4}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
added new API calls for encryption:
- pdfr_encoder_set_RC4_40_encrypter()
- pdfr_encoder_set_RC4_128_encrypter()
- pdfr_encoder_set_AES128_encrypter()
- pdfr_encoder_set_AES256_encrypter()

Each of new API takes as params: encoder, open password, master password, bit mask of permissions, boolean value for encrypting metadata.

According to PDF/R specs only AES256 should be supported. If you want I can remove rest of encryption algorithms (RC4 (40/128 bits, AES128).

AES256: here is still written PDF-1.7 as header. The Acrobat had problems with decrypting if header was 2.0. Nitro decrypted 2.0 PDF correctly.