### PR TITLE
Fixed bug for digital signature if file was smaller than 8192 bytes.

### DIFF
--- a/pdfras_writer/PdfDate.c
+++ b/pdfras_writer/PdfDate.c
@@ -52,7 +52,7 @@ char* pd_date_to_pdfstring(t_date* date) {
     char* ret = (char*)pd_alloc(date->pool, sizeof(char) * 25);
 
     char O;
-    pduint8 hour_offset = date->hour_offset;
+    pdint8 hour_offset = date->hour_offset;
     if (hour_offset < 0) {
         O = '-';
         hour_offset = hour_offset * -1;

--- a/pdfras_writer/PdfDigitalSignature.c
+++ b/pdfras_writer/PdfDigitalSignature.c
@@ -130,7 +130,7 @@ void digitalsignature_finish(t_pdfdigitalsignature* signature) {
     }
 
     offset2 += 1; 
-    length2 = signature->data->bufferSize - offset2;
+    length2 = signature->data->written - offset2;
 
     p = find_string_in_binary(signature->data->buffer, signature->data->written, "/ByteRange [");
     if (!p)
@@ -180,7 +180,7 @@ void digitalsignature_finish(t_pdfdigitalsignature* signature) {
 
     pd_free(buffer_to_sign);
 
-    signature->userWriter(signature->data->buffer, 0, signature->data->bufferSize, signature->userCookie);
+    signature->userWriter(signature->data->buffer, 0, signature->data->written, signature->userCookie);
 }
 
 // Destroy


### PR DESCRIPTION
- there was bug for digital signing if PDF was smaller than 8192 bytes. Fixed.