### PR TITLE
Digital signature validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ demo_raster_encoder/*.pdf
 
 .vscode/
 build/
+
+pdfras_tool/pdfras_tool.vcxproj.user

--- a/pdfras_digitalsignature/pdfras_digitalsignature.c
+++ b/pdfras_digitalsignature/pdfras_digitalsignature.c
@@ -4,6 +4,9 @@
 #include <string.h>
 
 #include "pdfras_digitalsignature.h"
+#ifdef _WIN32
+#include "pdfras_digitalsignature_windows.h"
+#endif // _WIN32
 
 #include "openssl/crypto.h"
 #include "openssl/pem.h"
@@ -18,6 +21,11 @@
 struct t_signer {
     EVP_PKEY* digsig_pkey;
     X509* digsig_cert;
+};
+
+struct t_digitalsignature {
+    struct t_signer* signer;
+    X509_STORE* cert_store;
 };
 
 pdbool static load_certificate(t_signer* signer, const char* file, const char* password) {
@@ -55,37 +63,66 @@ pdbool static load_certificate(t_signer* signer, const char* file, const char* p
     return PD_TRUE;
 }
 
-t_signer* PDFRASAPICALL pdfr_init_digitalsignature(const char* pfx_file, const char* password) {
+t_digitalsignature* PDFRASAPICALL pdfr_init_digitalsignature() {
     // initialization of OpenSSL
     ERR_load_BIO_strings();
     SSL_load_error_strings();
     OpenSSL_add_all_algorithms();
 
-    t_signer* signer = (t_signer*) malloc(sizeof(t_signer));
-    signer->digsig_cert = NULL;
-    signer->digsig_pkey = NULL;
+    t_digitalsignature* ds = (t_digitalsignature*)malloc(sizeof(t_digitalsignature));
+    ds->signer = NULL;
+    ds->cert_store = X509_STORE_new();
 
-    if (!load_certificate(signer, pfx_file, password)) {
-        pdfr_exit_digitalsignature(signer);
-        return NULL;
-    }
-
-    return signer;
+    return ds;
 }
 
-void PDFRASAPICALL pdfr_exit_digitalsignature(t_signer* signer) {
+pdbool PDFRASAPICALL pdfr_digitalsignature_create_signer(t_digitalsignature* ds, const char* pfx_file, const char* password) {
+    assert(ds);
+
+    if (ds->signer)
+        free(ds->signer);
+
+    ds->signer = (t_signer*) malloc(sizeof(t_signer));
+    ds->signer->digsig_cert = NULL;
+    ds->signer->digsig_pkey = NULL;
+
+    if (!load_certificate(ds->signer, pfx_file, password)) {
+        free(ds->signer);
+        ds->signer = NULL;
+
+        return PD_FALSE;
+    }
+
+    return PD_TRUE;
+}
+
+void PDFRASAPICALL pdfr_exit_digitalsignature(t_digitalsignature* ds) {
     // OpenSSL clean up
     ERR_free_strings();
     EVP_cleanup();
 
-    assert(signer);
-    free(signer);
-    signer = NULL;
+    assert(ds);
+    
+    if (ds->signer) {
+        free(ds->signer);
+        ds->signer = NULL;
+    }
+
+    if (ds->cert_store) {
+        X509_STORE_free(ds->cert_store);
+        ds->cert_store = NULL;
+    }
+
+    free(ds);
+    ds = NULL;
 }
 
 /* returns signature length used by Contents.
    If error ocurred then returns -1.*/
-pdint32 pdfr_digsig_signature_length(t_signer* signer) {
+pdint32 pdfr_digsig_signature_length(t_digitalsignature* ds) {
+    assert(ds);
+    assert(ds->signer);
+
     pdint32 ret = -1;
     pduint8 random_buff[10];
     pdint8 random_buff_size = 1;
@@ -95,7 +132,7 @@ pdint32 pdfr_digsig_signature_length(t_signer* signer) {
     
     PKCS7* pkcs7;
     pduint32 flags = PKCS7_DETACHED | PKCS7_BINARY;
-    pkcs7 = PKCS7_sign(signer->digsig_cert, signer->digsig_pkey, NULL, inputbio, flags);
+    pkcs7 = PKCS7_sign(ds->signer->digsig_cert, ds->signer->digsig_pkey, NULL, inputbio, flags);
     BIO_free(inputbio);
 
     if (pkcs7) {
@@ -116,15 +153,21 @@ pdint32 pdfr_digsig_signature_length(t_signer* signer) {
 }
 
 // sign data
-pdint32 pdfr_digsig_sign_data(t_signer* signer, const pduint8* input, const pdint32 input_length, pduint8* output, const pduint32 output_length) {
+pdint32 pdfr_digsig_sign_data(t_digitalsignature* ds, const pduint8* input, const pdint32 input_length, pduint8* output, const pduint32 output_length) {
+    assert(ds);
+    assert(ds->signer);
+
     pdint32 ret = -1;
 
     BIO* inputbio = BIO_new(BIO_s_mem());
+    if (inputbio == NULL)
+        return ret;
+
     BIO_write(inputbio, input, input_length);
 
     PKCS7* pkcs7;
     pduint32 flags = PKCS7_DETACHED | PKCS7_BINARY;
-    pkcs7 = PKCS7_sign(signer->digsig_cert, signer->digsig_pkey, NULL, inputbio, flags);
+    pkcs7 = PKCS7_sign(ds->signer->digsig_cert, ds->signer->digsig_pkey, NULL, inputbio, flags);
     BIO_free(inputbio);
 
     if (pkcs7) {
@@ -143,5 +186,51 @@ pdint32 pdfr_digsig_sign_data(t_signer* signer, const pduint8* input, const pdin
         PKCS7_free(pkcs7);
     }
 
+    return ret;
+}
+
+// validate data
+pdint32 pdfr_digitalsignature_validate(t_digitalsignature* ds, const pduint8* pkcs7, const pduint32 pkcs7_len, const pduint8* bytes, const pduint32 bytes_len) {
+    pduint32 ret = 0;
+
+    BIO* pkcs7Bio = BIO_new(BIO_s_mem());
+    if (pkcs7Bio == NULL)
+        return ret;
+
+    BIO_write(pkcs7Bio, pkcs7, pkcs7_len);    
+    
+    PKCS7* p7 = d2i_PKCS7_bio(pkcs7Bio, NULL);
+    if (p7 == NULL) {
+        BIO_free(pkcs7Bio);
+        return ret;
+    }
+
+    BIO* inDataBio = BIO_new(BIO_s_mem());
+    if (inDataBio == NULL) {
+        BIO_free(pkcs7Bio);
+        PKCS7_free(p7);
+        return ret;
+    }
+
+    BIO_write(inDataBio, bytes, bytes_len);
+
+#ifdef _WIN32
+    digsig_load_certificates_from_store(ds->cert_store);
+#endif // _WIN32
+
+    if (PKCS7_verify(p7, NULL, ds->cert_store, inDataBio, NULL, 0) == 1) {
+        ret |= DS_DOC_NOT_CHANGED;
+        ret |= DS_CERT_VERIFIED;
+    }
+    else {
+        if (PKCS7_verify(p7, NULL, ds->cert_store, inDataBio, NULL, PKCS7_NOVERIFY) == 1) {
+            ret |= DS_DOC_NOT_CHANGED;
+        }
+    }
+
+    BIO_free(pkcs7Bio);
+    BIO_free(inDataBio);
+    PKCS7_free(p7);
+    
     return ret;
 }

--- a/pdfras_digitalsignature/pdfras_digitalsignature.def
+++ b/pdfras_digitalsignature/pdfras_digitalsignature.def
@@ -5,3 +5,5 @@ EXPORTS
 	pdfr_exit_digitalsignature		@2
 	pdfr_digsig_signature_length	@3
 	pdfr_digsig_sign_data			@4
+	pdfr_digitalsignature_create_signer	@5
+	pdfr_digitalsignature_validate	@6

--- a/pdfras_digitalsignature/pdfras_digitalsignature.h
+++ b/pdfras_digitalsignature/pdfras_digitalsignature.h
@@ -7,31 +7,48 @@ extern "C" {
 
 #include "PdfPlatform.h"
 
+#define DS_DOC_NOT_CHANGED      0x1 // Document has not been changed
+#define DS_CERT_VERIFIED        0x2 // Certificate has been verified
+
+#define PDFR_DOC_WAS_NOT_CHANGED(x) (((x) & DS_DOC_NOT_CHANGED) == DS_DOC_NOT_CHANGED)
+#define PDFR_CERT_VERIFIED(x) (((x) & DS_CERT_VERIFIED) == DS_CERT_VERIFIED)
+
 typedef struct t_signer t_signer;
+typedef struct t_digitalsignature t_digitalsignature;
 
 // Initiliaze digital signature module
+// return: t_digitalsignature object
+t_digitalsignature* PDFRASAPICALL pdfr_init_digitalsignature(); //const char* pfx_file, const char* password);
+typedef t_digitalsignature* (PDFRASAPICALL *pfn_pdfr_init_digitalsignature) (); //const char* pfx_file, const char* password);
+
+// Create digital signature signer object
+// ds: t_digitalsignature object
 // pfx_file: PFX file with certificate
 // password: password for certificate
-t_signer* PDFRASAPICALL pdfr_init_digitalsignature(const char* pfx_file, const char* password);
-typedef t_signer* (PDFRASAPICALL *pfn_pdfr_init_digitalsignature) (const char* pfx_file, const char* password);
+pdbool PDFRASAPICALL pdfr_digitalsignature_create_signer(t_digitalsignature* ds, const char* pfx_file, const char* password);
+typedef pdbool (PDFRASAPICALL *pfn_pdfr_digitalsignature_create_signer) (t_digitalsignature* ds, const char* pfx_file, const char* password);
 
 // Called at the end of working with digital signature module
-void PDFRASAPICALL pdfr_exit_digitalsignature(t_signer* signer);
-typedef void (PDFRASAPICALL *pfn_pdfr_exit_digitalsignature) (t_signer* signer);
+void PDFRASAPICALL pdfr_exit_digitalsignature(t_digitalsignature* ds);
+typedef void (PDFRASAPICALL *pfn_pdfr_exit_digitalsignature) (t_digitalsignature* ds);
 
 // Computes digital signature lenght for Contents entry 
-pdint32 PDFRASAPICALL pdfr_digsig_signature_length(t_signer* signer);
-typedef pdint32(PDFRASAPICALL *pfn_pdfr_digsig_signature_length) (t_signer* signer);
+pdint32 PDFRASAPICALL pdfr_digsig_signature_length(t_digitalsignature* ds);
+typedef pdint32(PDFRASAPICALL *pfn_pdfr_digsig_signature_length) (t_digitalsignature* ds);
+
+// Validate PDF content
+pdint32 PDFRASAPICALL pdfr_digitalsignature_validate(t_digitalsignature* ds, const pduint8* pkcs7, const pduint32 pkcs7_len, const pduint8* bytes, const pduint32 bytes_len);
+typedef pdint32 (PDFRASAPICALL pfn_pdfr_digitalsignature_validate) (t_digitalsignature* ds, const pduint8* pkcs7, const pduint32 pkcs7_len, const pduint8* bytes, const pduint32 bytes_len);
 
 // Sign data with certificate
-// signer: certificate data
+// ds: t_digitalsignature object
 // input: input buffer to be signed
 // input_length: size of input buffer
 // output: signed data value (must be allocated by caller)
 // output_length: size of buffer for signed data. 
 //                If it smaller than signed data computed in function than function will return -1.
-pdint32 PDFRASAPICALL pdfr_digsig_sign_data(t_signer* signer, const pduint8* input, const pdint32 input_length, pduint8* output, const pduint32 output_length);
-typedef pdint32(PDFRASAPICALL *pfn_pdfr_digisig_sign_data) (t_signer* signer, const pduint8* input, const pdint32 input_length, const pduint8* output, const pduint32 output_length);
+pdint32 PDFRASAPICALL pdfr_digsig_sign_data(t_digitalsignature* ds, const pduint8* input, const pdint32 input_length, pduint8* output, const pduint32 output_length);
+typedef pdint32(PDFRASAPICALL *pfn_pdfr_digisig_sign_data) (t_digitalsignature* ds, const pduint8* input, const pdint32 input_length, const pduint8* output, const pduint32 output_length);
 
 #ifdef __cplusplus
 }

--- a/pdfras_digitalsignature/pdfras_digitalsignature.vcxproj
+++ b/pdfras_digitalsignature/pdfras_digitalsignature.vcxproj
@@ -187,9 +187,11 @@ copy $(MSBuildThisFileDirectory)certificate.p12 $(MSBuildThisFileDirectory)..\bi
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pdfras_digitalsignature.h" />
+    <ClInclude Include="pdfras_digitalsignature_windows.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pdfras_digitalsignature.c" />
+    <ClCompile Include="pdfras_digitalsignature_windows.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/pdfras_digitalsignature/pdfras_digitalsignature.vcxproj.filters
+++ b/pdfras_digitalsignature/pdfras_digitalsignature.vcxproj.filters
@@ -23,9 +23,15 @@
     <ClInclude Include="pdfras_digitalsignature.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="pdfras_digitalsignature_windows.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pdfras_digitalsignature.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="pdfras_digitalsignature_windows.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/pdfras_digitalsignature/pdfras_digitalsignature_windows.c
+++ b/pdfras_digitalsignature/pdfras_digitalsignature_windows.c
@@ -1,0 +1,47 @@
+// Windows specific functions
+#ifdef _WIN32
+#pragma comment(lib, "crypt32.lib")
+#endif // _WIN32
+
+#include "pdfras_digitalsignature_windows.h"
+
+#ifdef _WIN32
+#include <Windows.h>
+#include <wincrypt.h>
+#include "openssl/x509.h"
+
+static void load_certs_from_store(X509_STORE* x509_store, const char* name) {
+    if (x509_store == NULL)
+        return;
+
+    HCERTSTORE store;
+    PCCERT_CONTEXT context = NULL;
+
+    // Load from ROOT
+    store = CertOpenStore(CERT_STORE_PROV_SYSTEM_A, 0, NULL, CERT_SYSTEM_STORE_CURRENT_USER, name);
+    // system stores
+    // including Trust, CA, or Root
+    if (store == NULL)
+        return;
+
+    X509* x509;
+    while (context = CertEnumCertificatesInStore(store, context)) {
+        const unsigned char* cert = context->pbCertEncoded;
+        x509 = d2i_X509(NULL, &cert, context->cbCertEncoded);
+
+        if (x509) {
+            X509_STORE_add_cert(x509_store, x509);
+            X509_free(x509);
+        }
+    }
+
+    CertFreeCertificateContext(context);
+    CertCloseStore(store, 0);
+}
+
+void digsig_load_certificates_from_store(X509_STORE* x509_store) {
+    load_certs_from_store(x509_store, "ROOT");
+    load_certs_from_store(x509_store, "MY");
+}
+
+#endif // _WIN32

--- a/pdfras_digitalsignature/pdfras_digitalsignature_windows.h
+++ b/pdfras_digitalsignature/pdfras_digitalsignature_windows.h
@@ -1,0 +1,21 @@
+// Windows specifi functions
+#ifndef _H_PdfRaster_DigitalSignature_Windows
+#define _H_PdfRaster_DigitalSignature_Windows
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef _WIN32
+
+#include "pdfras_digitalsignature.h"
+#include "openssl/x509.h"
+
+void digsig_load_certificates_from_store(X509_STORE* x509_store);
+
+#endif // _WIN32
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/pdfras_reader/pdfras_reader.vcxproj
+++ b/pdfras_reader/pdfras_reader.vcxproj
@@ -33,6 +33,11 @@
       <DisableLanguageExtensions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DisableLanguageExtensions>
     </ClCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\pdfras_digitalsignature\pdfras_digitalsignature.vcxproj">
+      <Project>{ad94958a-b236-416c-b217-2bad5ecf7cc3}</Project>
+    </ProjectReference>
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{C06A94CA-439B-4C91-9FA3-F9C2E3487473}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
@@ -97,7 +102,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_digitalsignature;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
@@ -120,7 +125,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_digitalsignature;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
@@ -145,7 +150,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_digitalsignature;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
@@ -172,7 +177,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
-      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_digitalsignature;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>

--- a/pdfras_reader/pdfrasread.def
+++ b/pdfras_reader/pdfrasread.def
@@ -35,3 +35,11 @@ EXPORTS
 	pdfrasread_page_count_filename			@31
 	pdfrasread_open_file				@32
 	pdfrasread_open_filename			@33
+	
+	pdfrasread_is_digitally_signed		@34
+	pdfrasread_digital_signature_count	@35
+	pdfrasread_digital_signature_validate	@36
+	pdfrasread_digital_signature_name	@37
+	pdfrasread_digital_signature_contactinfo @38
+	pdfrasread_digital_signature_reason	@39
+	pdfrasread_digital_signature_location	@40

--- a/pdfras_reader/pdfrasread.h
+++ b/pdfras_reader/pdfrasread.h
@@ -10,6 +10,7 @@ extern "C" {
 #endif
 
 #include "PdfPlatform.h"
+#include "pdfras_digitalsignature.h"
 
 // This could be pduint32 for resource constrained 32-bit system using PDF/raster files smaller than 4GB
 typedef unsigned long long int pdfpos_t;
@@ -230,6 +231,41 @@ typedef unsigned long (PDFRASAPICALL *pfn_pdfrasread_strip_height)(t_pdfrasreade
 long PDFRASAPICALL pdfrasread_strip_raw_size(t_pdfrasreader* reader, int p, int s);
 typedef long (PDFRASAPICALL *pfn_pdfrasread_strip_raw_size)(t_pdfrasreader* reader, int p, int s);
 
+// API for digital signatures
+// Check if PDF/R document is digitally signed
+int PDFRASAPICALL pdfrasread_is_digitally_signed(t_pdfrasreader* reader);
+typedef int (PDFRASAPICALL *pfn_pdfrasread_is_digitally_signed)(t_pdfrasreader* reader);
+
+// Return number digital signatures found in PDF/R document
+int PDFRASAPICALL pdfrasread_digital_signature_count(t_pdfrasreader* reader);
+typedef int (PDFRASAPICALL *pfn_pdfrasread_digital_signature_count)(t_pdfrasreader* reader);
+
+// Validate digital signature at given position (zero based indices based on return value 
+// of pdfrasread_digital_signature_count()
+// 0 if signature is not valid, otherwise none zero value
+pdint32 PDFRASAPICALL pdfrasread_digital_signature_validate(t_pdfrasreader* reader, pdint32 idx);
+typedef pdint32 (PDFRASAPICALL *pfn_pdfrasread_digital_signature_validate) (t_pdfrasreader* reader, pdint32 idx);
+
+// Get /Name entry from digital signature dictionary
+// if buf is NULL then function returns count of bytes needed for buffer allcoated by caller
+size_t PDFRASAPICALL pdfrasread_digital_signature_name(t_pdfrasreader* reader, pdint32 idx, char* buf);
+typedef size_t(PDFRASAPICALL *pfn_pdfrasread_digital_signature_name) (t_pdfrasreader* reader, pdint32 idx, char* buf);
+
+// Get /ContactInfo entry from digital signature dictionary
+// if buf is NULL then function returns count of bytes needed for buffer allcoated by caller
+size_t PDFRASAPICALL pdfrasread_digital_signature_contactinfo(t_pdfrasreader* reader, pdint32 idx, char* buf);
+typedef size_t(PDFRASAPICALL *pfn_pdfrasread_digital_signature_contactinfo) (t_pdfrasreader* reader, pdint32 idx, char* buf);
+
+// Get /Reason entry from digital signature dictionary
+// if buf is NULL then function returns count of bytes needed for buffer allcoated by caller
+size_t PDFRASAPICALL pdfrasread_digital_signature_reason(t_pdfrasreader* reader, pdint32 idx, char* buf);
+typedef size_t(PDFRASAPICALL *pfn_pdfrasread_digital_signature_reason) (t_pdfrasreader* reader, pdint32 idx, char* buf);
+
+// Get /Location entry from digital signature dictionary
+// if buf is NULL then function returns count of bytes needed for buffer allcoated by caller
+size_t PDFRASAPICALL pdfrasread_digital_signature_location(t_pdfrasreader* reader, pdint32 idx, char* buf);
+typedef size_t(PDFRASAPICALL *pfn_pdfrasread_digital_signature_location) (t_pdfrasreader* reader, pdint32 idx, char* buf);
+
 // detailed error codes
 // TODO: assign hard codes to all, so they can't change accidentally
 // and so people can look 'em up.
@@ -331,6 +367,11 @@ typedef enum {
     READ_ICC_PROFILE,               // not a valid ICC Profile stream
     READ_ICCPROFILE_READ,           // read error while reading ICC Profile data
     READ_COLORSPACE_ARRAY,          // colorspace array syntax error - missing closing ']'?
+    READ_FIELDS_NOT_IN_AF,          // Fields entry is not present in AcroForms
+    READ_V_NOT_IN_FIELD,            // field of AcroForm does not contain /V
+    READ_BYTERANGE_NOT_FOUND,       // /ByteRange for digital signature was not found
+    READ_CONTENTS_IN_DS_NOT_FOUND,  // /Contents not present in digital signature dictionary
+    READ_BAD_STRING_BEGIN,          // Invalid begin mark for string object
     READ_pdfrt_error_code_COUNT
 } ReadErrorCode;
 

--- a/pdfras_reader_managed/PdfRasterReader.cpp
+++ b/pdfras_reader_managed/PdfRasterReader.cpp
@@ -244,6 +244,128 @@ namespace PdfRasterReader {
 		return strip_data;
 	}
 
+    bool Reader::decoder_is_digitally_signed(int idx) {
+        LOG(fprintf(fp, "> idx=%d", idx));
+        checkStateValid(idx);
+
+        int dig_signed = pdfrasread_is_digitally_signed(state[idx].decoder);
+        LOG(fprintf(fp, "- digitally signed = %d", dig_signed));
+
+        return dig_signed == 1 ? true : false;
+    }
+
+    int Reader::decoder_digital_siganture_count(int idx) {
+        LOG(fprintf(fp, "> idx=%d", idx));
+        checkStateValid(idx);
+
+        int count = pdfrasread_digital_signature_count(state[idx].decoder);
+        LOG(fprintf(fp, "- digital signature count = %d", count));
+
+        return count;
+    }
+
+    int Reader::decoder_digital_signature_validate(int idx, int ds_idx) {
+        LOG(fprintf(fp, "> idx=%d", idx));
+        checkStateValid(idx);
+
+        int res = pdfrasread_digital_signature_validate(state[idx].decoder, ds_idx);
+        LOG(fprintf(fp, " - digital signature validity = %d", res));
+
+        return res;
+    }
+
+    String^ Reader::decoder_digital_signature_name(int idx, int ds_idx) {
+        LOG(fprintf(fp, "> idx=%d", idx));
+        checkStateValid(idx);
+
+        char* buf = NULL;
+        size_t len = pdfrasread_digital_signature_name(state[idx].decoder, ds_idx, NULL);
+        if (len == 0) {
+            LOG(fprintf(fp, "- digital signagture name = null"));
+            return "";
+        }
+
+        buf = (char*)malloc(sizeof(char) * (len + 1));
+        len = pdfrasread_digital_signature_name(state[idx].decoder, ds_idx, buf);
+        buf[len] = '\0';
+
+        String^ ret = gcnew String(buf);
+        free(buf);
+
+        LOG(fprintf(fp, "- digital signagture name = %s", buf));
+
+        return ret;
+    }
+
+    String^ Reader::decoder_digital_signature_contactinfo(int idx, int ds_idx) {
+        LOG(fprintf(fp, "> idx=%d", idx));
+        checkStateValid(idx);
+
+        char* buf = NULL;
+        size_t len = pdfrasread_digital_signature_contactinfo(state[idx].decoder, ds_idx, NULL);
+        if (len == 0) {
+            LOG(fprintf(fp, "- digital signagture contact info = null"));
+            return "";
+        }
+
+        buf = (char*)malloc(sizeof(char) * (len + 1));
+        len = pdfrasread_digital_signature_contactinfo(state[idx].decoder, ds_idx, buf);
+        buf[len] = '\0';
+
+        String^ ret = gcnew String(buf);
+        free(buf);
+
+        LOG(fprintf(fp, "- digital signagture contact info = %s", buf));
+
+        return ret;
+    }
+
+    String^ Reader::decoder_digital_signature_reason(int idx, int ds_idx) {
+        LOG(fprintf(fp, "> idx=%d", idx));
+        checkStateValid(idx);
+
+        char* buf = NULL;
+        size_t len = pdfrasread_digital_signature_reason(state[idx].decoder, ds_idx, NULL);
+        if (len == 0) {
+            LOG(fprintf(fp, "- digital signagture reason = null"));
+            return "";
+        }
+
+        buf = (char*)malloc(sizeof(char) * (len + 1));
+        len = pdfrasread_digital_signature_reason(state[idx].decoder, ds_idx, buf);
+        buf[len] = '\0';
+
+        String^ ret = gcnew String(buf);
+        free(buf);
+
+        LOG(fprintf(fp, "- digital signagture reason = %s", buf));
+
+        return ret;
+    }
+
+    String^ Reader::decoder_digital_signature_location(int idx, int ds_idx) {
+        LOG(fprintf(fp, "> idx=%d", idx));
+        checkStateValid(idx);
+
+        char* buf = NULL;
+        size_t len = pdfrasread_digital_signature_location(state[idx].decoder, ds_idx, NULL);
+        if (len == 0) {
+            LOG(fprintf(fp, "- digital signagture location = null"));
+            return "";
+        }
+
+        buf = (char*)malloc(sizeof(char) * (len + 1));
+        len = pdfrasread_digital_signature_location(state[idx].decoder, ds_idx, buf);
+        buf[len] = '\0';
+
+        String^ ret = gcnew String(buf);
+        free(buf);
+
+        LOG(fprintf(fp, "- digital signagture location = %s", buf));
+
+        return ret;
+    }
+
 	void Reader::decoder_destroy(int idx)
 	{
 		LOG(fprintf(fp, "> idx=%d", idx));

--- a/pdfras_reader_managed/PdfRasterReader.h
+++ b/pdfras_reader_managed/PdfRasterReader.h
@@ -53,7 +53,14 @@ namespace PdfRasterReader {
 		double decoder_get_yresolution(int idx);
 		PdfRasterReaderPixelFormat decoder_get_pixelformat(int idx);
 		PdfRasterReaderCompression decoder_get_compression(int idx);
-		array<Byte>^ decoder_read_strips(int idx);
+        array<Byte>^ decoder_read_strips(int idx);
+        bool decoder_is_digitally_signed(int idx);
+        int decoder_digital_siganture_count(int idx);
+        int decoder_digital_signature_validate(int idx, int ds_idx);
+        String^ decoder_digital_signature_name(int idx, int ds_idx);
+        String^ decoder_digital_signature_contactinfo(int idx, int ds_idx);
+        String^ decoder_digital_signature_reason(int idx, int ds_idx);
+        String^ decoder_digital_signature_location(int idx, int ds_idx);
 		void decoder_destroy(int idx);
 #pragma endregion Public Methods for PdfRasterReader
 	};

--- a/pdfras_reader_managed/pdfras_reader_managed.vcxproj
+++ b/pdfras_reader_managed/pdfras_reader_managed.vcxproj
@@ -91,12 +91,13 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AdditionalIncludeDirectories>..\pdfras_reader;..\pdfras_writer;..\pdfras_encryption;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\pdfras_reader;..\pdfras_writer;..\pdfras_encryption;..\pdfras_digitalsignature;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
-      <AdditionalDependencies />
+      <AdditionalDependencies>pdfras_digitalsignature.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\bin\x86\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -105,12 +106,13 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AdditionalIncludeDirectories>..\pdfras_reader;..\pdfras_writer;..\pdfras_encryption;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\pdfras_reader;..\pdfras_writer;..\pdfras_encryption;..\pdfras_digitalsignature;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
-      <AdditionalDependencies />
+      <AdditionalDependencies>pdfras_digitalsignature.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>..\bin\x64\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -118,11 +120,12 @@
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AdditionalIncludeDirectories>..\pdfras_reader;..\pdfras_writer;..\pdfras_encryption;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\pdfras_reader;..\pdfras_writer;..\pdfras_encryption;..\pdfras_digitalsignature;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
-      <AdditionalDependencies />
+      <AdditionalDependencies>pdfras_digitalsignature.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\bin\x86\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -130,11 +133,12 @@
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AdditionalIncludeDirectories>..\pdfras_reader;..\pdfras_writer;..\pdfras_encryption;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\pdfras_reader;..\pdfras_writer;..\pdfras_encryption;..\pdfras_digitalsignature;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
-      <AdditionalDependencies />
+      <AdditionalDependencies>pdfras_digitalsignature.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\bin\x64\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/pdfras_reader_tests/pdfras_reader_tests.vcxproj
+++ b/pdfras_reader_tests/pdfras_reader_tests.vcxproj
@@ -87,7 +87,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)common;$(SolutionDir)pdfras_reader;$(SolutionDir)pdfras_writer</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)common;$(SolutionDir)pdfras_reader;$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_digitalsignature</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
@@ -103,7 +103,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)common;$(SolutionDir)pdfras_reader;$(SolutionDir)pdfras_writer</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)common;$(SolutionDir)pdfras_reader;$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_digitalsignature</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
@@ -121,7 +121,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)common;$(SolutionDir)pdfras_reader;$(SolutionDir)pdfras_writer</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)common;$(SolutionDir)pdfras_reader;$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_digitalsignature</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
@@ -141,7 +141,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)common;$(SolutionDir)pdfras_reader;$(SolutionDir)pdfras_writer</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)common;$(SolutionDir)pdfras_reader;$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_digitalsignature</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
@@ -174,6 +174,9 @@
     <None Include="valid1.pdf" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\pdfras_digitalsignature\pdfras_digitalsignature.vcxproj">
+      <Project>{ad94958a-b236-416c-b217-2bad5ecf7cc3}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\pdfras_reader\pdfras_reader.vcxproj">
       <Project>{c06a94ca-439b-4c91-9fa3-f9c2e3487473}</Project>
     </ProjectReference>

--- a/pdfras_tool/application.h
+++ b/pdfras_tool/application.h
@@ -53,5 +53,6 @@ private:
 	void pdfr_open();
 	void pdfr_parse_details();
 	void pdfr_parse_image();
+    void pdfr_signature_info();
 	void pdfr_close();
 };

--- a/pdfras_tool/configuration.h
+++ b/pdfras_tool/configuration.h
@@ -31,6 +31,7 @@ private:
 	const int test_pdfr = 1;			// test validity of PDFraster file
 	const int print_details = 2;		// print PDFraster (width, length, resolution, etc.)
 	const int extract_image = 4;		// extract image from PDFR file
+    const int print_signature = 8;      // print info about digital signature
 public:
 	operation() { op = test_pdfr; }
 
@@ -49,6 +50,10 @@ public:
 	void set_extract_image() { op = extract_image; }
 	void add_extract_image() { op |= extract_image; }
 	bool get_extract_image() { return op & extract_image ? true : false; }
+
+    void set_signature_info() { op = print_signature; }
+    void add_signature_info() { op |= print_signature; }
+    bool get_signature_info() { return op & print_signature ? true : false; }
 };
 
 class configuration {

--- a/pdfras_tool/pdfras_tool.vcxproj
+++ b/pdfras_tool/pdfras_tool.vcxproj
@@ -89,7 +89,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\pdfras_reader;..\pdfras_writer;;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\pdfras_reader;..\pdfras_writer;..\pdfras_digitalsignature;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
@@ -107,7 +107,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\pdfras_reader;..\pdfras_writer;;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\pdfras_reader;..\pdfras_writer;..\pdfras_digitalsignature;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
@@ -127,7 +127,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\pdfras_reader;..\pdfras_writer;;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\pdfras_reader;..\pdfras_writer;..\pdfras_digitalsignature;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
@@ -149,7 +149,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\pdfras_reader;..\pdfras_writer;;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\pdfras_reader;..\pdfras_writer;..\pdfras_digitalsignature;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
@@ -182,6 +182,9 @@
     <ClCompile Include="tiff.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\pdfras_digitalsignature\pdfras_digitalsignature.vcxproj">
+      <Project>{ad94958a-b236-416c-b217-2bad5ecf7cc3}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\pdfras_reader\pdfras_reader.vcxproj">
       <Project>{c06a94ca-439b-4c91-9fa3-f9c2e3487473}</Project>
     </ProjectReference>

--- a/pdfras_writer/PdfDigitalSignature.c
+++ b/pdfras_writer/PdfDigitalSignature.c
@@ -37,7 +37,7 @@ struct t_pdfdigitalsignature {
     t_writer_data* data;
 
     // data used by pdfras_digitalsignature module
-    t_signer* signer;
+    t_digitalsignature* ds;
 
     // page containing signature
     t_pdvalue page;
@@ -63,8 +63,15 @@ t_pdfdigitalsignature* digitalsignature_create(t_pdfrasencoder* encoder, const c
     if (!digitalSignature)
         return NULL;
 
-    digitalSignature->signer = pdfr_init_digitalsignature(pfx_file, password);
-    if (!digitalSignature->signer) {
+    digitalSignature->ds = pdfr_init_digitalsignature();
+    if (digitalSignature->ds == NULL) {
+        pd_free(digitalSignature);
+        return NULL;
+    }
+
+    pdbool result = pdfr_digitalsignature_create_signer(digitalSignature->ds, pfx_file, password);
+    if (!result) {
+        pdfr_exit_digitalsignature(digitalSignature->ds);
         pd_free(digitalSignature);
         return NULL;
     }
@@ -159,7 +166,7 @@ void digitalsignature_finish(t_pdfdigitalsignature* signature) {
     memset(signed_data, 0, sizeof(pduint8) * signed_len_in_hex);
     memset(signed_data_hex, 0, sizeof(pduint8) * (signed_len_in_hex + 1));
 
-    signed_len_in_bytes = pdfr_digsig_sign_data(signature->signer, buffer_to_sign, length1 + length2, signed_data, signed_len_in_hex);
+    signed_len_in_bytes = pdfr_digsig_sign_data(signature->ds, buffer_to_sign, length1 + length2, signed_data, signed_len_in_hex);
     if (signed_len_in_bytes > 0) {
         // converting to hex
         for (pduint32 i = 0; i < signed_len_in_bytes; ++i) {
@@ -187,7 +194,7 @@ void digitalsignature_finish(t_pdfdigitalsignature* signature) {
 void digitalsignature_destroy(t_pdfdigitalsignature* signature) {
     assert(signature);
 
-    pdfr_exit_digitalsignature(signature->signer);
+    pdfr_exit_digitalsignature(signature->ds);
 
     // restore user defined write callback and cookie
     pdfr_encoder_set_outputwriter(signature->encoder, signature->userWriter);
@@ -373,7 +380,7 @@ void digitalsignature_create_dictionaries(t_pdfdigitalsignature* signature) {
     memset(content, '0', 1024);
 
     // calculating lenght of the Content just to have accurate size 
-    pdint32 signature_length = pdfr_digsig_signature_length(signature->signer);
+    pdint32 signature_length = pdfr_digsig_signature_length(signature->ds);
     
     t_pdvalue v_dict = pd_dict_new(signature->pool, 3);
     pd_dict_put(v_dict, ((t_pdatom)"Contents"), pdstringvalue(pd_string_new_binary(signature->pool, signature_length, content)));

--- a/pdfras_writer_tests/pdfras_writer_tests.vcxproj
+++ b/pdfras_writer_tests/pdfras_writer_tests.vcxproj
@@ -82,7 +82,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_reader;$(SolutionDir)common;..\pdfras_encryption</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_reader;$(SolutionDir)common;$(SolutionDir)pdfras_encryption;$(SolutionDir)pdfras_digitalsignature</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
@@ -98,7 +98,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_reader;$(SolutionDir)common;..\pdfras_encryption</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_reader;$(SolutionDir)common;$(SolutionDir)pdfras_encryption;$(SolutionDir)pdfras_digitalsignature</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
@@ -116,7 +116,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_reader;$(SolutionDir)common;..\pdfras_encryption</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_reader;$(SolutionDir)common;$(SolutionDir)pdfras_encryption;$(SolutionDir)pdfras_digitalsignature</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
@@ -136,7 +136,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_reader;$(SolutionDir)common;..\pdfras_encryption</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)pdfras_writer;$(SolutionDir)pdfras_reader;$(SolutionDir)common;$(SolutionDir)pdfras_encryption;$(SolutionDir)pdfras_digitalsignature</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>


### PR DESCRIPTION
Digital signature validation introduces new APIs:
- pdfrasread_is_digitally_signed() - checks if PDF/R is digitally signed
- pdfrasread_digital_signature_count() - returns count of signatures (currently only 1 signature is supported because reader does not support incrementally saved files)
- pdfrasread_digital_signature_validate() - validates signature. 0 -> not valid, positive value signature is valid (macros PDFR_DOC_WAS_NOT_CHANGED(), PDFR_CERT_VERIFIED() to determine if document was changed or not, certificate was verified)
- pdfrasread_digital_signature_name() - get /Name
- pdfrasread_digital_signature_contactinfo() - get /ContactInfo
- pdfrasread_digital_signature_reason() - get /Reason
- pdfrasread_digital_signature_location - get /Location

Also .Net wrapper and pdfras_tool were updated.