### PR TITLE
Read xmp

### DIFF
--- a/demo_raster_encoder/demo_raster_encoder.c
+++ b/demo_raster_encoder/demo_raster_encoder.c
@@ -557,6 +557,8 @@ void write_gray8_jpeg_page(t_pdfrasencoder* enc)
 	pdfr_encoder_set_compression(enc, PDFRAS_JPEG);
 	// write a strip of raster data to the current page
 	pdfr_encoder_write_strip(enc, 1100, gray8_page_jpg, sizeof gray8_page_jpg);
+    // page metadata
+    pdfr_encoder_write_page_xmp(enc, XMP_metadata);
 	// the page is done
 	pdfr_encoder_end_page(enc);
 }

--- a/pdfras_reader/pdfrasread.def
+++ b/pdfras_reader/pdfrasread.def
@@ -43,3 +43,6 @@ EXPORTS
 	pdfrasread_digital_signature_contactinfo @38
 	pdfrasread_digital_signature_reason	@39
 	pdfrasread_digital_signature_location	@40
+	
+	pdfrasread_document_metadata		@41
+	pdfrasread_page_metadata			@42

--- a/pdfras_reader/pdfrasread.h
+++ b/pdfras_reader/pdfrasread.h
@@ -231,6 +231,20 @@ typedef unsigned long (PDFRASAPICALL *pfn_pdfrasread_strip_height)(t_pdfrasreade
 long PDFRASAPICALL pdfrasread_strip_raw_size(t_pdfrasreader* reader, int p, int s);
 typedef long (PDFRASAPICALL *pfn_pdfrasread_strip_raw_size)(t_pdfrasreader* reader, int p, int s);
 
+// Metadata reading API
+// metadata: buffer for storing metadata. If it's NULL, function return count of bytes needed 
+// for allocation of buffer for metadata. Buffer is null-terminated.
+// return metadata stream length
+size_t PDFRASAPICALL pdfrasread_document_metadata(t_pdfrasreader* reader, char* metadata);
+typedef size_t(PDFRASAPICALL *pfn_pdfrasread_document_metadata) (t_pdfrasreader* reader, char* metadata);
+
+// page: number of page
+// metadata: buffer for storing metadata. If it's NULL, function return count of bytes needed 
+// for allocation of buffer for metadata. Buffer is null-terminated.
+// return metadata stream length
+size_t PDFRASAPICALL pdfrasread_page_metadata(t_pdfrasreader* reader, int page, char* metadata);
+typedef size_t(PDFRASAPICALL *pfn_pdfrasread_page_metadata)(t_pdfrasreader* reader, int page, char* metadata);
+
 // API for digital signatures
 // Check if PDF/R document is digitally signed
 int PDFRASAPICALL pdfrasread_is_digitally_signed(t_pdfrasreader* reader);

--- a/pdfras_reader_managed/PdfRasterReader.cpp
+++ b/pdfras_reader_managed/PdfRasterReader.cpp
@@ -366,6 +366,57 @@ namespace PdfRasterReader {
         return ret;
     }
 
+    String^ Reader::decoder_document_metadata(int idx) {
+        LOG(fprintf("> idx=%d", idx));
+        checkStateValid(idx);
+
+        char* buf = NULL;
+        size_t len = pdfrasread_document_metadata(state[idx].decoder, NULL);
+        if (len == 0) {
+            LOG(fprintf(fp, "- document metadata length = 0"));
+            return "";
+        }
+
+        buf = (char*)malloc(sizeof(char) * len);
+        len = pdfrasread_document_metadata(state[idx].decoder, buf);
+
+        String^ ret = gcnew String(buf);
+        free(buf);
+
+        LOG(fprintf(fp, "- document metadata length = %d", len));
+
+        return ret;
+    }
+
+    // page: number of page indexed from 1 (1st page -> 1), not from 0
+    String^ Reader::decoder_page_metadata(int idx, int page) {
+        LOG(fprintf("> idx=%d", idx));
+        checkStateValid(idx);
+
+        if (page <= 0) {
+            LOG(fprintf("- page metadata = wrong page number"));
+            return "";
+        }
+
+        char* buf = NULL;
+        --page;
+        size_t len = pdfrasread_page_metadata(state[idx].decoder, page, NULL);
+        if (len == 0) {
+            LOG(fprintf(fp, "- page metadata length = 0"));
+            return "";
+        }
+
+        buf = (char*)malloc(sizeof(char) * len);
+        len = pdfrasread_page_metadata(state[idx].decoder, page, buf);
+
+        String^ ret = gcnew String(buf);
+        free(buf);
+
+        LOG(fprintf(fp, "- page metadata length = %d", len));
+
+        return ret;
+    }
+
 	void Reader::decoder_destroy(int idx)
 	{
 		LOG(fprintf(fp, "> idx=%d", idx));

--- a/pdfras_reader_managed/PdfRasterReader.h
+++ b/pdfras_reader_managed/PdfRasterReader.h
@@ -61,6 +61,8 @@ namespace PdfRasterReader {
         String^ decoder_digital_signature_contactinfo(int idx, int ds_idx);
         String^ decoder_digital_signature_reason(int idx, int ds_idx);
         String^ decoder_digital_signature_location(int idx, int ds_idx);
+        String^ decoder_document_metadata(int idx);
+        String^ decoder_page_metadata(int idx, int page); // page: number of page indexed from 1 (1st page -> 1), not from 0
 		void decoder_destroy(int idx);
 #pragma endregion Public Methods for PdfRasterReader
 	};


### PR DESCRIPTION
Metadata reading API:
- pdfrasread_document_metadata()
- pdfrasread_page_metadata()

Also I've added calling of pdfr_encoder_write_page_xmp() to test document. If page was not started this functin fails (do nothing).