### PR TITLE
query API function if document uses security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ demo_raster_encoder/*.pdf
 build/
 
 pdfras_tool/pdfras_tool.vcxproj.user
+pdfras_reader/pdfras_reader.vcxproj.user

--- a/pdfras_reader/pdfrasread.def
+++ b/pdfras_reader/pdfrasread.def
@@ -46,3 +46,6 @@ EXPORTS
 	
 	pdfrasread_document_metadata		@41
 	pdfrasread_page_metadata			@42
+	
+	pdfrasread_get_security_type		@43
+	pdfrasread_get_security_type_filename @44

--- a/pdfras_reader/pdfrasread.h
+++ b/pdfras_reader/pdfrasread.h
@@ -40,6 +40,13 @@ typedef enum {
 	RASREAD_CCITTG4,			// CCITT Group 4 (CCITTFaxDecode)
 } RasterReaderCompression;
 
+typedef enum {
+    RASREAD_SECURITY_UNKNOWN,              // Unknown, error occurred
+    RASREAD_UNENCRYPTED,                   // document is unencrypted
+    RASREAD_STANDARD_SECURITY,             // document is encrypted by password security
+    RASREAD_PUBLIC_KEY_SECURITY            // document is encrypted by certificate security
+} RasterReaderSecurityType; 
+
 // Error categories
 // All levels except INFO and WARNING indicate that the current API call will fail.
 #define	REPORTING_INFO      0		// useful to know but not bad news.
@@ -280,6 +287,11 @@ typedef size_t(PDFRASAPICALL *pfn_pdfrasread_digital_signature_reason) (t_pdfras
 size_t PDFRASAPICALL pdfrasread_digital_signature_location(t_pdfrasreader* reader, pdint32 idx, char* buf);
 typedef size_t(PDFRASAPICALL *pfn_pdfrasread_digital_signature_location) (t_pdfrasreader* reader, pdint32 idx, char* buf);
 
+// Decryption
+// Checks if document is encrypted
+RasterReaderSecurityType PDFRASAPICALL pdfrasread_get_security_type(t_pdfrasreader* reader, void* source);
+typedef RasterReaderSecurityType(PDFRASAPICALL *pfn_pdfrasread_get_security_type) (t_pdfrasreader* reader, void* source);
+
 // detailed error codes
 // TODO: assign hard codes to all, so they can't change accidentally
 // and so people can look 'em up.
@@ -386,6 +398,8 @@ typedef enum {
     READ_BYTERANGE_NOT_FOUND,       // /ByteRange for digital signature was not found
     READ_CONTENTS_IN_DS_NOT_FOUND,  // /Contents not present in digital signature dictionary
     READ_BAD_STRING_BEGIN,          // Invalid begin mark for string object
+    READ_ENCRYPT_FILTER_NOT_FOUND,  // Required /Filter not found in encryption dictionary
+    READ_BAD_NAME_BEGIN,            // Invalid begin mark for name object
     READ_pdfrt_error_code_COUNT
 } ReadErrorCode;
 

--- a/pdfras_reader/pdfrasread_files.c
+++ b/pdfras_reader/pdfrasread_files.c
@@ -1,6 +1,7 @@
 #include "pdfrasread_files.h"
 #include <string.h>
 #include <ctype.h>
+#include <stdlib.h>
 #include "PdfPlatform.h"
 
 // Some private helper functions
@@ -117,4 +118,22 @@ t_pdfrasreader* pdfrasread_open_filename(int apiLevel, const char* fn)
 		}
 	}
 	return reader;
+}
+
+RasterReaderSecurityType pdfrasread_get_security_type_filename(const char* filename) {
+    t_pdfrasreader* reader = pdfrasread_create(RASREAD_API_LEVEL, &file_reader, &file_sizer, &file_closer);
+    RasterReaderSecurityType ret = RASREAD_SECURITY_UNKNOWN;
+
+    if (reader) {
+        FILE* f = fopen(filename, "rb");
+    
+        if (f) {
+             ret = pdfrasread_get_security_type(reader, f);
+            fclose(f);
+        }
+
+        free(reader);
+    }
+
+    return ret;
 }

--- a/pdfras_reader/pdfrasread_files.h
+++ b/pdfras_reader/pdfrasread_files.h
@@ -32,6 +32,10 @@ typedef t_pdfrasreader* (PDFRASAPICALL *pfn_pdfrasread_open_file)(int apiLevel, 
 t_pdfrasreader* PDFRASAPICALL pdfrasread_open_filename(int apiLevel, const char* fn);
 typedef t_pdfrasreader* (PDFRASAPICALL *pfn_pdfrasread_open_filename)(int apiLevel, const char* fn);
 
+// return security type used by document
+RasterReaderSecurityType PDFRASAPICALL pdfrasread_get_security_type_filename(const char* filename);
+typedef RasterReaderSecurityType(PDFRASAPICALL *pfn_pdfrasread_get_security_type_filename)(const char* filename);
+
 #ifdef __cplusplus
 }
 #endif

--- a/pdfras_reader_managed/PdfRasterReader.cpp
+++ b/pdfras_reader_managed/PdfRasterReader.cpp
@@ -210,6 +210,22 @@ namespace PdfRasterReader {
 		return compression;
 	}
 
+    Reader::PdfRasterReaderSecurityType Reader::decoder_get_security_type(String^ pdfFileName) {
+        char *filename = wchar2char(pdfFileName);
+        RasterReaderSecurityType st = pdfrasread_get_security_type_filename(filename);
+        
+        PdfRasterReaderSecurityType security;
+        switch (st) {
+        case RASREAD_SECURITY_UNKNOWN: security = PdfRasterReaderSecurityType::PDFRASREAD_SECURITY_UNKNOWN; break;
+        case RASREAD_UNENCRYPTED: security = PdfRasterReaderSecurityType::PDFRASREAD_UNENCRYPTED; break;
+        case RASREAD_STANDARD_SECURITY: security = PdfRasterReaderSecurityType::RASREAD_STANDARD_SECURITY; break;
+        case RASREAD_PUBLIC_KEY_SECURITY: security = PdfRasterReaderSecurityType::RASREAD_PUBLIC_KEY_SECURITY; break;
+        default: LOG(fprintf(fp, "> unknown security type!")); throw("unknown security type"); break;
+        }
+
+        return security;
+    }
+
 	array<Byte>^ Reader::decoder_read_strips(int idx)
 	{
 		LOG(fprintf(fp, "> idx=%d", idx));

--- a/pdfras_reader_managed/PdfRasterReader.h
+++ b/pdfras_reader_managed/PdfRasterReader.h
@@ -38,6 +38,15 @@ namespace PdfRasterReader {
 			PDFRASREAD_JPEG = RASREAD_JPEG,							// JPEG baseline (DCTDecode)
 			PDFRASEARD_CCITTG4 = RASREAD_CCITTG4,					// CCITT Group 4 (CCITTFaxDecode)
 		};
+
+        // Security type
+        enum struct PdfRasterReaderSecurityType
+        {
+            PDFRASREAD_SECURITY_UNKNOWN = RASREAD_SECURITY_UNKNOWN, // Unknown, error occurred
+            PDFRASREAD_UNENCRYPTED = RASREAD_UNENCRYPTED,           // document is unencrypted
+            RASREAD_STANDARD_SECURITY = RASREAD_STANDARD_SECURITY,  // document is encrypted by password security
+            RASREAD_PUBLIC_KEY_SECURITY = RASREAD_PUBLIC_KEY_SECURITY, // document is encrypted by certificate security
+        };
 #pragma endregion Public Definitions for PdfRasterReader
 
 		///////////////////////////////////////////////////////////////////////////////
@@ -53,6 +62,7 @@ namespace PdfRasterReader {
 		double decoder_get_yresolution(int idx);
 		PdfRasterReaderPixelFormat decoder_get_pixelformat(int idx);
 		PdfRasterReaderCompression decoder_get_compression(int idx);
+        PdfRasterReaderSecurityType decoder_get_security_type(String^ filename);
         array<Byte>^ decoder_read_strips(int idx);
         bool decoder_is_digitally_signed(int idx);
         int decoder_digital_signature_count(int idx);


### PR DESCRIPTION
New API function for requesting if document has applied security:
RasterReaderSecurityType pdfrasread_get_security_type(t_pdfrasreader* reader, void* source);

Also managed code has wrapper for this new API function:
PdfRasterReaderSecurityType decoder_get_security_type(String^ filename);

Functions can be called before opening file.