### PR TITLE
Certificate security (encryption)

### DIFF
--- a/demo_raster_encoder/demo_raster_encoder.c
+++ b/demo_raster_encoder/demo_raster_encoder.c
@@ -1007,7 +1007,9 @@ int write_rgb24_jpeg_file_encrypted_aes256(t_OS os, const char* filename) {
     os.allocsys = pd_alloc_new_pool(&os);
 
     t_pdfrasencoder* enc = pdfr_encoder_create(PDFRAS_API_LEVEL, &os);
+ 
     pdfr_encoder_set_AES256_encrypter(enc, "open", "master", PDFRAS_PERM_COPY_FROM_DOCUMENT, PD_FALSE);
+
     pdfr_encoder_set_creator(enc, "raster_encoder_demo 1.0");
     pdfr_encoder_set_title(enc, filename);
     pdfr_encoder_set_subject(enc, "24-bit JPEG-compressed sample output");
@@ -1261,4 +1263,3 @@ int main(int argc, char** argv)
     getchar();
     return 0;
 }
-

--- a/pdfras_encryption/pdfras_data_structures.h
+++ b/pdfras_encryption/pdfras_data_structures.h
@@ -1,0 +1,73 @@
+#ifndef _H_PdfRaster_DataStructures
+#define _H_PdfRaster_DataStructures
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "PdfPlatform.h"
+
+    typedef enum {
+        PDFRAS_RC4_40,   // RC4 with encryption key length of 40 bits
+        PDFRAS_RC4_128,  // RC4 with ecnryption key length of 128 bits
+        PDFRAS_AES_128,  // AES with encryption key length of 128 bits
+        PDFRAS_AES_256,  // AES with encryption key lenght of 256 bits
+        PDFRAS_UNDEFINED_ENCRYPT_ALGORITHM
+    } PDFRAS_ENCRYPT_ALGORITHM;
+
+    typedef enum {
+        PDFRAS_PERM_UNKNOWN = 0x00000000,
+        PDFRAS_PERM_PRINT_DOCUMENT = 0x00000004,
+        PDFRAS_PERM_MODIFY_DOCUMENT = 0x00000008,
+        PDFRAS_PERM_COPY_FROM_DOCUMENT = 0x00000010,
+        PDFRAS_PERM_EDIT_ANNOTS = 0x00000020,
+        PDFRAS_PERM_FILL_FORMS = 0x00000100,
+        PDFRAS_PERM_ACCESSIBILITY = 0x00000200,
+        PDFRAS_PERM_ASSEMBLE_DOCUMENT = 0x00000400,
+        PDFRAS_PERM_HIGH_PRINT = 0x00000800,
+        PDFRAS_PERM_ALL = (0x00000004 | 0x00000008 | 0x00000010 | 0x00000020 | 0x00000100 | 0x00000200 | 0x00000400 | 0x00000800),
+    } PDFRAS_PERMS;
+
+    typedef enum {
+        PDFRAS_DOCUMENT_NONE_ACCESS,      // None access to the document
+        PDFRAS_DOCUMENT_USER_ACCESS,      // User access to the document
+        PDFRAS_DOCUMENT_OWNER_ACCESS      // Owner access to the document (full access)
+    } PDFRAS_DOCUMENT_ACCESS;
+
+    typedef struct t_encrypter t_encrypter;
+    typedef struct t_encrypter t_decrypter;
+
+    // Used by pubsec security.
+    // Defines recipient (contains only encrypted blob for /Recipients in encrypt dictionary)
+    struct t_recipient {
+        char* pkcs7_blob;
+        pduint32 pkcs7_blob_size;
+        struct t_recipient* next;
+    };
+
+    typedef struct t_recipient t_recipient;
+
+    typedef struct {
+        PDFRAS_ENCRYPT_ALGORITHM algorithm;
+        PDFRAS_PERMS perms;
+        char* O;
+        char* U;
+        char* OE;
+        char* UE;
+        char* Perms;
+        char* document_id;
+        pduint32 OU_length;
+        pduint32 OUE_length;
+        pduint32 Perms_length;
+        pduint32 document_id_length;
+        pduint8 R;
+        pduint8 V;
+        pduint8 encryption_key_length;
+        pdbool encrypt_metadata;
+    } RasterReaderEncryptData;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _H_PdfRaster_DataStructures

--- a/pdfras_encryption/pdfras_encryption.def
+++ b/pdfras_encryption/pdfras_encryption.def
@@ -26,3 +26,7 @@ EXPORTS
 	pdfr_decrypter_get_algorithm				@24
 	pdfr_decrypter_object_number				@25
 	pdfr_decrypter_get_metadata_encrypted		@26
+	pdfr_encrypter_is_password_security			@27
+	pdfr_create_pubsec_encrypter				@28
+	pdfr_encrypter_pubsec_recipients_count		@29
+	pdfr_encrypter_pubsec_recipient_pkcs7		@30

--- a/pdfras_encryption/pdfras_encryption.vcxproj
+++ b/pdfras_encryption/pdfras_encryption.vcxproj
@@ -20,13 +20,18 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="aes_crypter.h" />
+    <ClInclude Include="pdfras_data_structures.h" />
     <ClInclude Include="pdfras_encryption.h" />
+    <ClInclude Include="pubsec.h" />
     <ClInclude Include="rc4_crypter.h" />
+    <ClInclude Include="recipient.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="aes_crypter.c" />
     <ClCompile Include="pdfras_encryption.c" />
+    <ClCompile Include="pubsec.c" />
     <ClCompile Include="rc4_crypter.c" />
+    <ClCompile Include="recipient.c" />
   </ItemGroup>
   <ItemGroup>
     <None Include="pdfras_encryption.def" />

--- a/pdfras_encryption/pdfras_encryption.vcxproj.filters
+++ b/pdfras_encryption/pdfras_encryption.vcxproj.filters
@@ -24,6 +24,15 @@
     <ClInclude Include="aes_crypter.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="pdfras_data_structures.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="recipient.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="pubsec.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pdfras_encryption.c">
@@ -33,6 +42,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="aes_crypter.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="recipient.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="pubsec.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/pdfras_encryption/pubsec.c
+++ b/pdfras_encryption/pubsec.c
@@ -1,0 +1,101 @@
+// pubsec_utils.c: function needed by public security
+#include "pubsec.h"
+
+#include "openssl/crypto.h"
+#include "openssl/pem.h"
+#include "openssl/err.h"
+#include "openssl/bio.h"
+#include "openssl/err.h"
+#include "openssl/cms.h"
+
+#include <string.h>
+
+// returned X509 cert must be freed by X509_free()
+static X509* load_public_key_cert(const char* pub_key_file) {
+    BIO* fileBIO = NULL;
+    X509* pubKeyCert = NULL;
+
+    fileBIO = BIO_new_file(pub_key_file, "rb");
+    if (!fileBIO)
+        return NULL;
+
+    pubKeyCert = PEM_read_bio_X509(fileBIO, NULL, NULL, NULL);
+    if (!pubKeyCert)
+        pubKeyCert = d2i_X509_bio(fileBIO, NULL);
+
+    BIO_free_all(fileBIO);
+
+    return pubKeyCert;
+}
+
+char* encrypt_recipient_message(const char* pub_key_file, char* message, pduint8 message_size, pduint32* out_blob_size, pdbool aesV3) {
+    if (!pub_key_file)
+        return NULL;
+
+    pdbool error = PD_FALSE;
+    X509* pub_key_cert = NULL;
+    STACK_OF(X509)* stack_certs = NULL;
+
+    BIO* messageBIO = BIO_new(BIO_s_mem());
+    if (!messageBIO) {
+        return NULL;
+    }
+    BIO_write(messageBIO, message, message_size);
+
+    pub_key_cert = load_public_key_cert(pub_key_file);
+    if (!pub_key_cert)
+        error = PD_TRUE;
+
+    if (!error) {
+        stack_certs = sk_X509_new_null();
+        if (!stack_certs) {
+            error = PD_TRUE;
+        }
+    }
+
+    if (!error) {
+        if (!sk_X509_push(stack_certs, pub_key_cert)) {
+            error = PD_TRUE;
+        }
+    }
+
+    char* blob = NULL;
+    if (!error) {
+        CMS_ContentInfo* cms = NULL; 
+        if (aesV3)
+            cms = CMS_encrypt(stack_certs, messageBIO, EVP_aes_256_cbc(), CMS_BINARY);
+        else
+            cms = CMS_encrypt(stack_certs, messageBIO, EVP_aes_128_cbc(), CMS_BINARY);
+
+        if (!cms)
+            error = PD_TRUE;
+
+        BIO* cmsBIO = BIO_new(BIO_s_mem());
+        i2d_CMS_bio(cmsBIO, cms);
+        BIO_flush(cmsBIO);
+
+        BUF_MEM* mem = NULL;
+        BIO_get_mem_ptr(cmsBIO, &mem);
+
+        if (mem && mem->data) {
+            blob = (char*)malloc(sizeof(char) * mem->length);
+            if (out_blob_size)
+                *out_blob_size = (pduint32)mem->length;
+
+            memcpy(blob, mem->data, mem->length);
+        }
+
+        BIO_free(cmsBIO);
+        CMS_ContentInfo_free(cms);
+    }
+
+
+    if (pub_key_cert)
+        X509_free(pub_key_cert);
+    if (stack_certs)
+        sk_X509_free(stack_certs);
+    if (messageBIO)
+        BIO_free_all(messageBIO);
+
+    return blob;
+}

--- a/pdfras_encryption/pubsec.h
+++ b/pdfras_encryption/pubsec.h
@@ -1,0 +1,16 @@
+#ifndef _H_PdfRaster_PubSec
+#define _H_PdfRaster_PubSec
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "PdfPlatform.h"
+
+ extern char* encrypt_recipient_message(const char* pub_key_file, char* message, pduint8 message_size, pduint32* out_blob_size, pdbool aesV3);
+ 
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _H_PdfRaster_PubSec

--- a/pdfras_encryption/recipient.c
+++ b/pdfras_encryption/recipient.c
@@ -1,0 +1,103 @@
+// pdfras_recipient.c: handling recpient data structure
+
+#include <stdlib.h>
+#include <string.h>
+#include "pdfras_data_structures.h"
+#include "pubsec.h"
+
+#define PUBSEC_SEED_LEN 20
+
+pdbool add_recipient(t_recipient** root, const char* pub_key, PDFRAS_PERMS perms, const char* seed, PDFRAS_ENCRYPT_ALGORITHM algorithm) {
+    t_recipient* recipient = NULL;
+
+    if (!(*root)) {
+        *root = (t_recipient*)malloc(sizeof(t_recipient));
+
+        (*root)->pkcs7_blob = NULL;
+        (*root)->pkcs7_blob_size = 0;
+        (*root)->next = NULL;
+
+        recipient = *root;
+    }
+    else {
+        // find last recipient in the list
+        if (!(*root)->next) {
+            recipient = *root;
+        }
+        else {
+            recipient = (*root)->next;
+            while (recipient && recipient->next) {
+                recipient = recipient->next;
+            }
+        }
+
+        // create new recipient
+        t_recipient* new_recipient = (t_recipient*)malloc(sizeof(t_recipient));
+        if (!new_recipient)
+            return PD_FALSE;
+
+        new_recipient->pkcs7_blob = NULL;
+        new_recipient->pkcs7_blob_size = 0;
+        new_recipient->next = NULL;
+
+        // link new recipient to last one found
+        recipient->next = new_recipient;
+
+        // last recipient created
+        recipient = new_recipient;
+    }
+
+    // create PKCS7 Blob for /Recipients in Encrypt dictionary
+    char message[PUBSEC_SEED_LEN + 4];
+    pduint32 uPerms = (pduint32) perms;
+    uPerms |= 0x01;  // Set bit for opening document
+    memcpy(message, seed, PUBSEC_SEED_LEN);
+
+    message[PUBSEC_SEED_LEN] = (pduint8)((uPerms >> 24) & 0xFF);
+    message[PUBSEC_SEED_LEN + 1] = (pduint8)((uPerms >> 16) & 0xFF);
+    message[PUBSEC_SEED_LEN + 2] = (pduint8)((uPerms >> 8) & 0xFF);
+    message[PUBSEC_SEED_LEN + 3] = (pduint8)(uPerms & 0xFF);
+
+    recipient->pkcs7_blob = encrypt_recipient_message(pub_key, message, (pduint8) PUBSEC_SEED_LEN + 4, &recipient->pkcs7_blob_size, algorithm == PDFRAS_AES_256 ? PD_TRUE : PD_FALSE);
+
+    if (!recipient->pkcs7_blob)
+        return PD_FALSE;
+
+    return PD_TRUE;
+}
+
+static void delete_recipient(t_recipient* recipient) {
+    if (recipient) {
+        if (recipient->pkcs7_blob)
+            free(recipient->pkcs7_blob);
+
+        free(recipient);
+        recipient = NULL;
+    }
+}
+
+void delete_recipients(t_recipient* root) {
+    if (!root)
+        return;
+
+    t_recipient* recipient = root;
+    while (recipient) {
+        t_recipient* next = recipient->next;
+        delete_recipient(recipient);
+        recipient = next;
+    }
+}
+
+pduint32 recipients_count(t_recipient* root) {
+    pduint32 count = 0;
+    
+    if (root) {
+        t_recipient* recipient = root;
+        while (recipient) {
+            ++count;
+            recipient = recipient->next;
+        }
+    }
+
+    return count;
+}

--- a/pdfras_encryption/recipient.h
+++ b/pdfras_encryption/recipient.h
@@ -1,0 +1,19 @@
+#ifndef _H_PdfRaster_Recipient
+#define _H_PdfRaster_Recipient
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "PdfPlatform.h"
+#include "pdfras_data_structures.h"
+
+extern pdbool add_recipient(t_recipient** root, const char* pub_key, PDFRAS_PERMS perms, const char* seed, PDFRAS_ENCRYPT_ALGORITHM algorithm);
+extern void delete_recipients(t_recipient* root);
+extern pduint32 recipients_count(t_recipient* root);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _H_PdfRaster_Recipient

--- a/pdfras_writer/PdfRaster.c
+++ b/pdfras_writer/PdfRaster.c
@@ -703,6 +703,19 @@ void pdfr_encoder_set_AES256_encrypter(t_pdfrasencoder* enc, const char* user_pa
     pd_outstream_set_encrypter(enc->stm, enc->encrypter);
 }
 
+void pdfr_encoder_set_pubsec_encrypter(t_pdfrasencoder* enc, const RasterPubSecRecipient* recipients, size_t recipients_count, PDFRAS_ENCRYPT_ALGORITHM algorithm, pdbool metadata) {
+    assert(enc);
+
+    if (enc->encrypter)
+        pd_encrypt_free(enc->encrypter);
+
+    enc->encrypter = pd_encrypt_new_pubsec(enc->pool, recipients, recipients_count, algorithm, metadata);
+    if (enc->encrypter) {
+        pd_encrypt_dictionary(enc->encrypter, enc->xref, &enc->trailer);
+        pd_outstream_set_encrypter(enc->stm, enc->encrypter);
+    }
+}
+
 void pdfr_encoder_destroy(t_pdfrasencoder* enc)
 {
     if (enc->signer)

--- a/pdfras_writer/PdfRaster.h
+++ b/pdfras_writer/PdfRaster.h
@@ -56,6 +56,7 @@ typedef enum {
 
 typedef struct t_pdfrasencoder t_pdfrasencoder;
 typedef struct t_pdfdigitalsignature t_pdfdigitalsignature;
+typedef struct RasterPubSecRecipient RasterPubSecRecipient;
 
 // create and return a raster PDF encoder, reading to begin
 // encoding a PDF/raster output stream.
@@ -276,6 +277,10 @@ typedef void (PDFRASAPICALL *pfn_pdfr_encoder_set_AES128_encrypter) (t_pdfrasenc
 // AES 256 bits
 void PDFRASAPICALL pdfr_encoder_set_AES256_encrypter(t_pdfrasencoder* enc, const char* user_password, const char* owner_password, PDFRAS_PERMS perms, pdbool metadata);
 typedef void (PDFRASAPICALL *pfn_pdfr_encoder_set_AES256_encrypter) (t_pdfrasencoder* enc, const char* user_password, const char* owner_password, pdint32 perms, pdbool metadata);
+
+// Public key security encryption
+void PDFRASAPICALL pdfr_encoder_set_pubsec_encrypter(t_pdfrasencoder* enc, const RasterPubSecRecipient* recipients, size_t recipients_count, PDFRAS_ENCRYPT_ALGORITHM algorithm, pdbool metadata);
+typedef void (PDFRASAPICALL *pfn_pdfr_encoder_set_pubsec_encrypter) (t_pdfrasencoder* enc, const RasterPubSecRecipient* recipients, size_t recipients_count, PDFRAS_ENCRYPT_ALGORITHM algorithm, pdbool metadata);
 
 #ifdef __cplusplus
 }

--- a/pdfras_writer/PdfSecurityHandler.h
+++ b/pdfras_writer/PdfSecurityHandler.h
@@ -11,9 +11,13 @@ extern "C" {
 #include "PdfValues.h"
 
 typedef struct t_pdencrypter t_pdencrypter;
+typedef struct RasterPubSecRecipient RasterPubSecRecipient;
 
 // Create a new encrytper.
 extern t_pdencrypter* pd_encrypt_new(t_pdmempool* pool, const char* user_passwd, const char* owner_passwd, PDFRAS_PERMS perms, PDFRAS_ENCRYPT_ALGORITHM algoritm, pdbool encrypt_metada, const char* document_id, pdint32 id_len);
+
+// Create new encrypter for Public key security
+extern t_pdencrypter* pd_encrypt_new_pubsec(t_pdmempool* pool, const RasterPubSecRecipient* recipients, size_t recipients_count, PDFRAS_ENCRYPT_ALGORITHM algorithm, pdbool encrypt_metadata);
 
 // free encrypter
 extern void pd_encrypt_free(t_pdencrypter* crypter);

--- a/pdfras_writer/PdfStreaming.c
+++ b/pdfras_writer/PdfStreaming.c
@@ -443,48 +443,6 @@ static void writestring(t_pdoutstream *stm, t_pdstring *str)
 	else if (pd_string_is_binary(str))
 	{	// write using the hex string notation
 		put_hex_string(stm, str);
-    /*    pd_putc(stm, '(');
-        int len = pd_string_length(str);
-        char* data = pd_string_data(str);
-        for (int i = 0; i < len; ++i) {
-            char c = data[i];
-            if (c == '\n') {
-                pd_putc(stm, '\\');
-                pd_putc(stm, 'n');
-            }
-            else if (c == '\r') {
-                pd_putc(stm, '\\');
-                pd_putc(stm, 'r');
-            }
-            else if (c == '\t') {
-                pd_putc(stm, '\\');
-                pd_putc(stm, 't');
-            }
-            else if (c == '\b') {
-                pd_putc(stm, '\\');
-                pd_putc(stm, 'b');
-            }
-            else if (c == '\f') {
-                pd_putc(stm, '\\');
-                pd_putc(stm, 'f');
-            }
-            else if (c == ')') {
-                pd_putc(stm, '\\');
-                pd_putc(stm, ')');
-            }
-            else if (c == '(') {
-                pd_putc(stm, '\\');
-                pd_putc(stm, '(');
-            }
-            else if (c == '\\') {
-                pd_putc(stm, '\\');
-                pd_putc(stm, '\'');
-            }
-            else
-                pd_putc(stm, c);
-
-        }
-        pd_putc(stm, ')');*/
 	}
 	else
 	{

--- a/pdfras_writer/PdfStreaming.c
+++ b/pdfras_writer/PdfStreaming.c
@@ -443,6 +443,48 @@ static void writestring(t_pdoutstream *stm, t_pdstring *str)
 	else if (pd_string_is_binary(str))
 	{	// write using the hex string notation
 		put_hex_string(stm, str);
+    /*    pd_putc(stm, '(');
+        int len = pd_string_length(str);
+        char* data = pd_string_data(str);
+        for (int i = 0; i < len; ++i) {
+            char c = data[i];
+            if (c == '\n') {
+                pd_putc(stm, '\\');
+                pd_putc(stm, 'n');
+            }
+            else if (c == '\r') {
+                pd_putc(stm, '\\');
+                pd_putc(stm, 'r');
+            }
+            else if (c == '\t') {
+                pd_putc(stm, '\\');
+                pd_putc(stm, 't');
+            }
+            else if (c == '\b') {
+                pd_putc(stm, '\\');
+                pd_putc(stm, 'b');
+            }
+            else if (c == '\f') {
+                pd_putc(stm, '\\');
+                pd_putc(stm, 'f');
+            }
+            else if (c == ')') {
+                pd_putc(stm, '\\');
+                pd_putc(stm, ')');
+            }
+            else if (c == '(') {
+                pd_putc(stm, '\\');
+                pd_putc(stm, '(');
+            }
+            else if (c == '\\') {
+                pd_putc(stm, '\\');
+                pd_putc(stm, '\'');
+            }
+            else
+                pd_putc(stm, c);
+
+        }
+        pd_putc(stm, ')');*/
 	}
 	else
 	{

--- a/pdfras_writer/pdfraswrite.def
+++ b/pdfras_writer/pdfraswrite.def
@@ -39,6 +39,7 @@ EXPORTS
 	pdfr_encoder_set_RC4_128_encrypter	@61
 	pdfr_encoder_set_AES128_encrypter	@62
 	pdfr_encoder_set_AES256_encrypter	@63
+	pdfr_encoder_set_pubsec_encrypter	@64
 	
 	pd_outstream_new				@100
 	pd_outstream_free				@101

--- a/pdfras_writer_managed/PdfRasterWriter.cpp
+++ b/pdfras_writer_managed/PdfRasterWriter.cpp
@@ -278,6 +278,78 @@ namespace PdfRasterWriter {
         LOG(fprintf(fp, "<"));
     }
 
+    void Writer::encoder_set_pubsec_RC4_128_encrypter(int idx, List<PdfRasterPubSecRecipient>^ recipients, pdbool metadata) {
+        LOG(fprintf(fp, "> idx=%d", idx));
+        checkStateValid(idx);
+
+        int recipients_count = recipients->Count;
+        RasterPubSecRecipient* c_recipients = (RasterPubSecRecipient*)malloc(sizeof(RasterPubSecRecipient) * recipients_count);
+
+        int recipient_idx = 0;
+        for each(PdfRasterPubSecRecipient recipient in recipients) {
+            c_recipients[recipient_idx].pubkey = (const char*)(Marshal::StringToHGlobalAnsi(recipient.public_key)).ToPointer();
+            c_recipients[recipient_idx].perms = (PDFRAS_PERMS)recipient.perms;
+            ++recipient_idx;
+        }
+        
+        pdfr_encoder_set_pubsec_encrypter(state[idx].enc, c_recipients, recipients_count, PDFRAS_RC4_128, metadata);
+
+        for (int i = 0; i < recipients_count; ++i) {
+            Marshal::FreeHGlobal(IntPtr((void*)c_recipients[i].pubkey));
+        }
+
+        free(c_recipients);
+        LOG(fprintf(fp, "<"));
+    }
+
+    void Writer::encoder_set_pubsec_AES128_encrypter(int idx, List<PdfRasterPubSecRecipient>^ recipients, pdbool metadata) {
+        LOG(fprintf(fp, "> idx=%d", idx));
+        checkStateValid(idx);
+
+        int recipients_count = recipients->Count;
+        RasterPubSecRecipient* c_recipients = (RasterPubSecRecipient*)malloc(sizeof(RasterPubSecRecipient) * recipients_count);
+
+        int recipient_idx = 0;
+        for each(PdfRasterPubSecRecipient recipient in recipients) {
+            c_recipients[recipient_idx].pubkey = (const char*)(Marshal::StringToHGlobalAnsi(recipient.public_key)).ToPointer();
+            c_recipients[recipient_idx].perms = (PDFRAS_PERMS)recipient.perms;
+            ++recipient_idx;
+        }
+
+        pdfr_encoder_set_pubsec_encrypter(state[idx].enc, c_recipients, recipients_count, PDFRAS_AES_128, metadata);
+
+        for (int i = 0; i < recipients_count; ++i) {
+            Marshal::FreeHGlobal(IntPtr((void*)c_recipients[i].pubkey));
+        }
+
+        free(c_recipients);
+        LOG(fprintf(fp, "<"));
+    }
+
+    void Writer::encoder_set_pubsec_AES256_encrypter(int idx, List<PdfRasterPubSecRecipient>^ recipients, pdbool metadata) {
+        LOG(fprintf(fp, "> idx=%d", idx));
+        checkStateValid(idx);
+
+        int recipients_count = recipients->Count;
+        RasterPubSecRecipient* c_recipients = (RasterPubSecRecipient*)malloc(sizeof(RasterPubSecRecipient) * recipients_count);
+
+        int recipient_idx = 0;
+        for each(PdfRasterPubSecRecipient recipient in recipients) {
+            c_recipients[recipient_idx].pubkey = (const char*)(Marshal::StringToHGlobalAnsi(recipient.public_key)).ToPointer();
+            c_recipients[recipient_idx].perms = (PDFRAS_PERMS)recipient.perms;
+            ++recipient_idx;
+        }
+
+        pdfr_encoder_set_pubsec_encrypter(state[idx].enc, c_recipients, recipients_count, PDFRAS_AES_256, metadata);
+
+        for (int i = 0; i < recipients_count; ++i) {
+            Marshal::FreeHGlobal(IntPtr((void*)c_recipients[i].pubkey));
+        }
+
+        free(c_recipients);
+        LOG(fprintf(fp, "<"));
+    }
+
 	void Writer::encoder_set_creator(int idx, String^ creator)
 	{
 		LOG(fprintf(fp, "> idx=%d", idx));

--- a/pdfras_writer_managed/PdfRasterWriter.h
+++ b/pdfras_writer_managed/PdfRasterWriter.h
@@ -3,6 +3,7 @@
 #pragma once
 
 using namespace System;
+using namespace System::Collections::Generic;
 
 namespace PdfRasterWriter {
 
@@ -47,8 +48,16 @@ namespace PdfRasterWriter {
 			PDFRASWR_PERM_FILL_FORMS = PDFRAS_PERM_FILL_FORMS,
 			PDFRASWR_PERM_ACCESSIBILITY = PDFRAS_PERM_ACCESSIBILITY,
 			PDFRASWR_PERM_ASSEMBLE_DOCUMENT = PDFRAS_PERM_ASSEMBLE_DOCUMENT,
-			PDFRASWR_PERM_HIGH_PRINT = PDFRAS_PERM_HIGH_PRINT
+			PDFRASWR_PERM_HIGH_PRINT = PDFRAS_PERM_HIGH_PRINT,
+            PDFRASWR_PERM_ALL = PDFRAS_PERM_ALL
 		};
+
+        value struct PdfRasterPubSecRecipient
+        {
+            String^ public_key;
+            PdfRasterPermissions perms;
+
+        };
 #pragma endregion Public Definitions for PdfRasterWriter
 
         ///////////////////////////////////////////////////////////////////////////////
@@ -62,6 +71,9 @@ namespace PdfRasterWriter {
         void encoder_set_RC4_128_encrypter(int idx, String^ user_password, String^ owner_password, PdfRasterPermissions perms, pdbool metadata);
         void encoder_set_AES128_encrypter(int idx, String^ user_password, String^ owner_password, PdfRasterPermissions perms, pdbool metadata);
         void encoder_set_AES256_encrypter(int idx, String^ user_password, String^ owner_password, PdfRasterPermissions perms, pdbool metadata);
+        void encoder_set_pubsec_RC4_128_encrypter(int idx, List<PdfRasterPubSecRecipient>^ recipients, pdbool metadata);
+        void encoder_set_pubsec_AES128_encrypter(int idx, List<PdfRasterPubSecRecipient>^ recipients, pdbool metadata);
+        void encoder_set_pubsec_AES256_encrypter(int idx, List<PdfRasterPubSecRecipient>^ recipients, pdbool metadata);
 		void encoder_set_creator(int enc, String^ creator);
 		void encoder_set_resolution(int enc, double xdpi, double ydpi);
 		void encoder_set_pixelformat(int enc, PdfRasterPixelFormat format);


### PR DESCRIPTION
Certificate security (encryption part):
new APIs:
void pdfr_encoder_set_pubsec_encrypter() -> applies certificate security for given encoder. It takes array of RasterPubSecRecipient which has two attributes: pubkey -> path to the PEM encoded certificate with public key, and perms -> permissions for given user (same as for password security).

Managed code version has these new methods for Writer:
void encoder_set_pubsec_RC4_128_encrypter(int idx, List<PdfRasterPubSecRecipient>^ recipients, pdbool metadata);
        void encoder_set_pubsec_AES128_encrypter(int idx, List<PdfRasterPubSecRecipient>^ recipients, pdbool metadata);
        void encoder_set_pubsec_AES256_encrypter(int idx, List<PdfRasterPubSecRecipient>^ recipients, pdbool metadata);

List of recipients defines recipients, metadata if document's metadata should be encrypted or not.