### PR TITLE
Certificate security: decryption

### DIFF
--- a/demo_raster_encoder/demo_raster_encoder.c
+++ b/demo_raster_encoder/demo_raster_encoder.c
@@ -316,7 +316,7 @@ int write_bitonal_uncompressed_signed_and_encrypted_file(t_OS os, const char* fi
     sprintf(cert_path + (demo - image_path), "%s", "certificate.p12");
     t_pdfrasencoder* enc = pdfr_signed_encoder_create(PDFRAS_API_LEVEL, &os, cert_path, "");
     pdfr_encoder_set_AES128_encrypter(enc, "open", "master", PDFRAS_PERM_COPY_FROM_DOCUMENT, PD_TRUE);
-
+   
     pdfr_encoder_set_creator(enc, "raster_encoder_demo 1.0");
     pdfr_encoder_set_subject(enc, "BW 1-bit Uncompressed sample output");
 
@@ -950,6 +950,7 @@ int write_rgb24_jpeg_file_encrypted_rc4_128(t_OS os, const char* filename) {
 
     t_pdfrasencoder* enc = pdfr_encoder_create(PDFRAS_API_LEVEL, &os);
     pdfr_encoder_set_RC4_128_encrypter(enc, "open", "master", PDFRAS_PERM_COPY_FROM_DOCUMENT, PD_FALSE);
+    
     pdfr_encoder_set_creator(enc, "raster_encoder_demo 1.0");
     pdfr_encoder_set_title(enc, filename);
     pdfr_encoder_set_subject(enc, "24-bit JPEG-compressed sample output");
@@ -979,6 +980,7 @@ int write_rgb24_jpeg_file_encrypted_aes128(t_OS os, const char* filename) {
 
     t_pdfrasencoder* enc = pdfr_encoder_create(PDFRAS_API_LEVEL, &os);
     pdfr_encoder_set_AES128_encrypter(enc, "open", "master", PDFRAS_PERM_COPY_FROM_DOCUMENT, PD_TRUE);
+    
     pdfr_encoder_set_creator(enc, "raster_encoder_demo 1.0");
     pdfr_encoder_set_title(enc, filename);
     pdfr_encoder_set_subject(enc, "24-bit JPEG-compressed sample output");
@@ -1009,7 +1011,7 @@ int write_rgb24_jpeg_file_encrypted_aes256(t_OS os, const char* filename) {
     t_pdfrasencoder* enc = pdfr_encoder_create(PDFRAS_API_LEVEL, &os);
  
     pdfr_encoder_set_AES256_encrypter(enc, "open", "master", PDFRAS_PERM_COPY_FROM_DOCUMENT, PD_FALSE);
-
+    
     pdfr_encoder_set_creator(enc, "raster_encoder_demo 1.0");
     pdfr_encoder_set_title(enc, filename);
     pdfr_encoder_set_subject(enc, "24-bit JPEG-compressed sample output");

--- a/pdfras_encryption/pdfras_data_structures.h
+++ b/pdfras_encryption/pdfras_data_structures.h
@@ -64,6 +64,7 @@ extern "C" {
         pduint8 V;
         pduint8 encryption_key_length;
         pdbool encrypt_metadata;
+        t_recipient* recipients;
     } RasterReaderEncryptData;
 
 #ifdef __cplusplus

--- a/pdfras_encryption/pdfras_encryption.def
+++ b/pdfras_encryption/pdfras_encryption.def
@@ -30,3 +30,9 @@ EXPORTS
 	pdfr_create_pubsec_encrypter				@28
 	pdfr_encrypter_pubsec_recipients_count		@29
 	pdfr_encrypter_pubsec_recipient_pkcs7		@30
+	pdfr_pubsec_add_recipient					@31
+	pdfr_pubsec_delete_recipients				@32
+	pdfr_pubsec_recipients_count				@33
+	pdfr_pubsec_add_existing_recipient			@34
+	pdfr_pubsec_decrypt_recipient				@35
+	pdfr_decrypter_get_pubsec_recipients		@36

--- a/pdfras_encryption/pdfras_encryption.h
+++ b/pdfras_encryption/pdfras_encryption.h
@@ -104,8 +104,8 @@ typedef const char* (PDFRASAPICALL pfn_pdfr_encrypter_pubsec_recipient_pkcs7) (t
 // Decryption
 // Creates decrypter used for authentification of user and decryption of encrypted file.
 // encrypt_data: encryption data extracted from /Encrypt dictionary
-t_decrypter* PDFRASAPICALL pdfr_create_decrypter(const RasterReaderEncryptData* encrypt_data);
-typedef t_decrypter* (PDFRASAPICALL *pfn_pdfr_create_decrypter) (const RasterReaderEncryptData* encrypt_data);
+t_decrypter* PDFRASAPICALL pdfr_create_decrypter(RasterReaderEncryptData* encrypt_data);
+typedef t_decrypter* (PDFRASAPICALL *pfn_pdfr_create_decrypter) (RasterReaderEncryptData* encrypt_data);
 
 // Destroy decrypter object.
 void PDFRASAPICALL pdfr_destroy_decrypter(t_decrypter* decrypter);
@@ -130,6 +130,10 @@ typedef void (PDFRASAPICALL *pfn_pdfr_decrypter_object_number) (t_decrypter* dec
 // Check if metadata are encrypted
 pdbool PDFRASAPICALL pdfr_decrypter_get_metadata_encrypted(t_decrypter* decrypter);
 typedef pdbool(PDFRASAPICALL *pfn_pdfr_decrypter_get_metadata_encrypted) (t_decrypter* decrypter);
+
+// Get Recipients for Pubkey security
+t_recipient* PDFRASAPICALL pdfr_decrypter_get_pubsec_recipients(t_decrypter* decrypter);
+typedef t_recipient* (PDFRASAPICALL pfn_pdfr_decrypter_get_pubsec_recipients) (t_decrypter* decrypter);
 
 #ifdef __cplusplus
 }

--- a/pdfras_encryption/pubsec.c
+++ b/pdfras_encryption/pubsec.c
@@ -1,4 +1,8 @@
 // pubsec_utils.c: function needed by public security
+#ifdef _WIN32
+#pragma comment(lib, "crypt32.lib")
+#endif // _WIN32
+
 #include "pubsec.h"
 
 #include "openssl/crypto.h"
@@ -7,8 +11,19 @@
 #include "openssl/bio.h"
 #include "openssl/err.h"
 #include "openssl/cms.h"
+#include "openssl/x509.h"
 
 #include <string.h>
+
+#ifdef _WIN32
+#include <Windows.h>
+#include <wincrypt.h>
+
+#define WIN_DECRYPT_MESSAGE_SIZE 32
+
+#endif
+
+#define DECRYPTED_MESSAGE_SIZE  24
 
 // returned X509 cert must be freed by X509_free()
 static X509* load_public_key_cert(const char* pub_key_file) {
@@ -32,7 +47,6 @@ char* encrypt_recipient_message(const char* pub_key_file, char* message, pduint8
     if (!pub_key_file)
         return NULL;
 
-    pdbool error = PD_FALSE;
     X509* pub_key_cert = NULL;
     STACK_OF(X509)* stack_certs = NULL;
 
@@ -43,33 +57,31 @@ char* encrypt_recipient_message(const char* pub_key_file, char* message, pduint8
     BIO_write(messageBIO, message, message_size);
 
     pub_key_cert = load_public_key_cert(pub_key_file);
-    if (!pub_key_cert)
-        error = PD_TRUE;
-
-    if (!error) {
-        stack_certs = sk_X509_new_null();
-        if (!stack_certs) {
-            error = PD_TRUE;
-        }
+    if (!pub_key_cert) {
+        BIO_free_all(messageBIO);
+        return NULL;
     }
 
-    if (!error) {
-        if (!sk_X509_push(stack_certs, pub_key_cert)) {
-            error = PD_TRUE;
-        }
+    stack_certs = sk_X509_new_null();
+    if (!stack_certs) {
+        BIO_free_all(messageBIO);
+        return NULL;
+    }
+
+    if (!sk_X509_push(stack_certs, pub_key_cert)) {
+        BIO_free_all(messageBIO);
+        sk_X509_free(stack_certs);
+        return NULL;
     }
 
     char* blob = NULL;
-    if (!error) {
-        CMS_ContentInfo* cms = NULL; 
-        if (aesV3)
-            cms = CMS_encrypt(stack_certs, messageBIO, EVP_aes_256_cbc(), CMS_BINARY);
-        else
-            cms = CMS_encrypt(stack_certs, messageBIO, EVP_aes_128_cbc(), CMS_BINARY);
+    CMS_ContentInfo* cms = NULL; 
+    if (aesV3)
+        cms = CMS_encrypt(stack_certs, messageBIO, EVP_aes_256_cbc(), CMS_BINARY);
+    else
+        cms = CMS_encrypt(stack_certs, messageBIO, EVP_aes_128_cbc(), CMS_BINARY);
 
-        if (!cms)
-            error = PD_TRUE;
-
+    if (cms) {
         BIO* cmsBIO = BIO_new(BIO_s_mem());
         i2d_CMS_bio(cmsBIO, cms);
         BIO_flush(cmsBIO);
@@ -85,11 +97,10 @@ char* encrypt_recipient_message(const char* pub_key_file, char* message, pduint8
             memcpy(blob, mem->data, mem->length);
         }
 
-        BIO_free(cmsBIO);
+        BIO_free_all(cmsBIO);
         CMS_ContentInfo_free(cms);
     }
-
-
+    
     if (pub_key_cert)
         X509_free(pub_key_cert);
     if (stack_certs)
@@ -98,4 +109,43 @@ char* encrypt_recipient_message(const char* pub_key_file, char* message, pduint8
         BIO_free_all(messageBIO);
 
     return blob;
+}
+
+pdbool decrypt_recipient_message(const char* in_blob, pduint32 in_len, const char* password, char** message, pduint32* message_len) {
+    // On Windows platform we use Windows crypto API to decrypt message
+#ifdef _WIN32
+    HCERTSTORE certStore = CertOpenSystemStore(NULL, L"MY");
+    if (!certStore)
+        return PD_FALSE;
+
+    CRYPT_DECRYPT_MESSAGE_PARA decryptParams;
+    memset(&decryptParams, 0, sizeof(CRYPT_DECRYPT_MESSAGE_PARA));
+    decryptParams.cbSize = sizeof(CRYPT_DECRYPT_MESSAGE_PARA); 
+    decryptParams.dwMsgAndCertEncodingType = PKCS_7_ASN_ENCODING ;
+    decryptParams.cCertStore = 1;
+    decryptParams.rghCertStore = &certStore;
+
+    *message = (char*)malloc(sizeof(char) * DECRYPTED_MESSAGE_SIZE);
+    memset(*message, 0, DECRYPTED_MESSAGE_SIZE);
+
+    char* buffer = (char*)malloc(sizeof(char) * WIN_DECRYPT_MESSAGE_SIZE);
+    *message_len = WIN_DECRYPT_MESSAGE_SIZE;
+    if (CryptDecryptMessage(&decryptParams, in_blob, in_len, buffer, message_len, NULL) == FALSE) {
+        free(*message);
+        free(buffer);
+        *message_len = 0;
+        CertCloseStore(certStore, 0);
+
+        return PD_FALSE;
+    }
+
+    memcpy(*message, buffer, DECRYPTED_MESSAGE_SIZE);
+    free(buffer);
+
+    CertCloseStore(certStore, 0);
+
+    return PD_TRUE;
+#endif
+
+    return PD_FALSE;
 }

--- a/pdfras_encryption/pubsec.h
+++ b/pdfras_encryption/pubsec.h
@@ -6,8 +6,14 @@ extern "C" {
 #endif
 
 #include "PdfPlatform.h"
+#include "openssl/x509.h"
 
  extern char* encrypt_recipient_message(const char* pub_key_file, char* message, pduint8 message_size, pduint32* out_blob_size, pdbool aesV3);
+ extern pdbool decrypt_recipient_message(const char* in_blob, pduint32 in_len, const char* password, char** message, pduint32* message_len);
+
+#ifdef _WIN32
+ extern void pubsec_load_certificates_from_store(X509_STORE* x509_store);
+#endif
  
 #ifdef __cplusplus
 }

--- a/pdfras_encryption/recipient.h
+++ b/pdfras_encryption/recipient.h
@@ -8,9 +8,22 @@ extern "C" {
 #include "PdfPlatform.h"
 #include "pdfras_data_structures.h"
 
-extern pdbool add_recipient(t_recipient** root, const char* pub_key, PDFRAS_PERMS perms, const char* seed, PDFRAS_ENCRYPT_ALGORITHM algorithm);
-extern void delete_recipients(t_recipient* root);
-extern pduint32 recipients_count(t_recipient* root);
+pdbool PDFRASAPICALL pdfr_pubsec_add_recipient(t_recipient** root, const char* pub_key, PDFRAS_PERMS perms, const char* seed, PDFRAS_ENCRYPT_ALGORITHM algorithm);
+typedef pdbool (PDFRASAPICALL *pfn_pdfr_pubsec_add_recipient) (t_recipient** root, const char* pub_key, PDFRAS_PERMS perms, const char* seed, PDFRAS_ENCRYPT_ALGORITHM algorithm);
+
+// calling function becomes the owner of the buffer.
+void PDFRASAPICALL pdfr_pubsec_add_existing_recipient(t_recipient** root, char* pkcs7_blob, pduint32 pkcs7_len);
+typedef void (PDFRASAPICALL *pfn_pdfr_pubsec_add_existing_recipient) (t_recipient** root, char* pkcs7_blob, pduint32 pkcs7_len);
+
+void PDFRASAPICALL pdfr_pubsec_delete_recipients(t_recipient* root);
+typedef void (PDFRASAPICALL *pfn_pdfr_pubsec_delete_recipients) (t_recipient* root);
+
+pduint32 PDFRASAPICALL pdfr_pubsec_recipients_count(t_recipient* root);
+typedef pduint32(PDFRASAPICALL *pfn_pdfr_recipients_count) (t_recipient* root);
+
+// Function will allocate buffer itself.
+pdbool PDFRASAPICALL pdfr_pubsec_decrypt_recipient(t_recipient* recipients, const char* password, char** decrypted_blob, pduint32* decrypted_blob_len);
+typedef pdbool(PDFRASAPICALL pfn_pdfr_pubsec_decrypt_recipient)(t_recipient* recipients, const char* password, char** decrypted_blob, pduint32* decrypted_blob_len);
 
 #ifdef __cplusplus
 }

--- a/pdfras_reader/pdfrasread.h
+++ b/pdfras_reader/pdfrasread.h
@@ -147,6 +147,8 @@ typedef int (PDFRASAPICALL *pfn_pdfrasread_open)(t_pdfrasreader* reader, void* s
 // It also fails if the source does not pass initial parsing/tests for PDF/raster.
 // No assumptions are made about the source parameter, it is only stored,
 // and passed to the readfn and closefn of the reader.
+// password: if document is secured by standard security it is password for opening. If the document
+// is secured by public key security then it's password for private key of user.
 int PDFRASAPICALL pdfrasread_open_secured(t_pdfrasreader* reader, void* source, const char* password);
 typedef int (PDFRASAPICALL *pfn_pdfrasread_open_secured) (t_pdfrasreader* reader, void* source, const char* password);
 
@@ -415,6 +417,8 @@ typedef enum {
     READ_NO_DOCUMENT_ID,            // Document has not ID (required by encryption/decryption)
     READ_ARRAY_BAD_SYNTAX,          // Array has bad syntax
     READ_ENCRYPTION_BAD_PASSWORD,    // Bad password provided for encrypted document
+    READ_ENCRYPTION_BAD_SECURITY_TYPE, // Bad security type used in document.
+    READ_ENCRYPTION_NO_RECIPIENTS,   // No recipients found for public key security.
     READ_pdfrt_error_code_COUNT
 } ReadErrorCode;
 

--- a/pdfras_reader_managed/PdfRasterReader.cpp
+++ b/pdfras_reader_managed/PdfRasterReader.cpp
@@ -119,9 +119,14 @@ namespace PdfRasterReader {
         char *filename = wchar2char(pdfFileName);
         LOG(fprintf(fp, "- filename=\"%s\"", filename));
 
-        char* passwd = wchar2char(password);
+        char* passwd = nullptr;
+        if (password)
+            passwd = wchar2char(password);
 
         state[idx].decoder = pdfrasread_open_filename_secured(RASREAD_API_LEVEL, filename, passwd);
+
+        if (passwd)
+            delete[] passwd;
 
         if (state[idx].decoder == nullptr) {
             state[idx].invalidate();

--- a/pdfras_tool/application.cpp
+++ b/pdfras_tool/application.cpp
@@ -176,6 +176,12 @@ void application::pdfr_open() {
             ERR(PDFRAS_READER_OPEN_FAIL);
         }
     }
+    else if (security_type == RASREAD_PUBLIC_KEY_SECURITY) {
+        if (FALSE == pdfrasread_open_secured(handle.get_reader(), handle.ifile.get_fp(), config.get_password())) {
+            LOG(err, "| error opening secured pdfras_reader handle for \"%s\"", handle.ifile.get_fp());
+            ERR(PDFRAS_READER_OPEN_FAIL);
+        }
+    }
     else {
         LOG(err, "| unknown security type used for \"%s\"", handle.ifile.get_fp());
         ERR(PDFRAS_READER_OPEN_FAIL);


### PR DESCRIPTION
Ceritificate security: decryption. No new APIs introduced, for decryption is used same API as for standard (password) security. The password will be used as password for private key. The private key of recipient is looked for in Windows certificate store. Later I'll add the option to enter path to private key located in file.